### PR TITLE
add support for constructors, nested classes, and chained methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 # OS X
 .DS_Store
 ._*
+
+.vs/
+.vshistory/

--- a/src/Analysis/Codelyzer.Analysis.Build/ProjectBuildHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.Build/ProjectBuildHandler.cs
@@ -67,7 +67,7 @@ namespace Codelyzer.Analysis.Build
             }
         }
 
-        private async void FallbackCompilation()
+        private void FallbackCompilation()
         {
             var options = (CSharpCompilationOptions) this.Project.CompilationOptions;
             var meta = this.Project.MetadataReferences;

--- a/src/Analysis/Codelyzer.Analysis.CSharp/CSharpRoslynProcessor.cs
+++ b/src/Analysis/Codelyzer.Analysis.CSharp/CSharpRoslynProcessor.cs
@@ -137,6 +137,24 @@ namespace Codelyzer.Analysis.CSharp
             return handler.UstNode;
         }
 
+        public override UstNode VisitConstructorDeclaration(ConstructorDeclarationSyntax node)
+        {
+            ConstructorDeclarationHandler handler = new ConstructorDeclarationHandler(context, node);
+            handler.UstNode.Children.Add(VisitBlock(node.Body));
+
+            var identifierNames = node.DescendantNodes().OfType<IdentifierNameSyntax>();
+            foreach (var identifierName in identifierNames)
+            {
+                var identifier = VisitIdentifierName((IdentifierNameSyntax)identifierName);
+                if (identifier != null)
+                {
+                    handler.UstNode.Children.Add(identifier);
+                }
+            }
+
+            return handler.UstNode;
+        }
+
         public override UstNode VisitMethodDeclaration(MethodDeclarationSyntax node)
         {
             MethodDeclarationHandler handler = new MethodDeclarationHandler(context, node);

--- a/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/ClassDeclarationHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/ClassDeclarationHandler.cs
@@ -1,6 +1,5 @@
 using Codelyzer.Analysis.Common;
 using Codelyzer.Analysis.Model;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -21,6 +20,7 @@ namespace Codelyzer.Analysis.CSharp.Handlers
             if (classSymbol != null && classSymbol.BaseType != null)
             {
                 ClassDeclaration.BaseType = classSymbol.BaseType.ToString();
+                ClassDeclaration.BaseTypeOriginalDefinition = classSymbol.BaseType.OriginalDefinition.ToString();
                 ClassDeclaration.Reference.Namespace = GetNamespace(classSymbol);
                 ClassDeclaration.Reference.Assembly = GetAssembly(classSymbol);
                 ClassDeclaration.Reference.AssemblySymbol = classSymbol.ContainingAssembly;

--- a/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/ClassDeclarationHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/ClassDeclarationHandler.cs
@@ -20,7 +20,7 @@ namespace Codelyzer.Analysis.CSharp.Handlers
             if (classSymbol != null && classSymbol.BaseType != null)
             {
                 ClassDeclaration.BaseType = classSymbol.BaseType.ToString();
-                ClassDeclaration.BaseTypeOriginalDefinition = classSymbol.BaseType.OriginalDefinition.ToString();
+                ClassDeclaration.BaseTypeOriginalDefinition = GetBaseTypOriginalDefinition(classSymbol); 
                 ClassDeclaration.Reference.Namespace = GetNamespace(classSymbol);
                 ClassDeclaration.Reference.Assembly = GetAssembly(classSymbol);
                 ClassDeclaration.Reference.AssemblySymbol = classSymbol.ContainingAssembly;

--- a/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/ConstructorDeclarationHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/ConstructorDeclarationHandler.cs
@@ -1,0 +1,46 @@
+﻿using Codelyzer.Analysis.Common;
+using Codelyzer.Analysis.Model;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+ 
+namespace Codelyzer.Analysis.CSharp.Handlers
+{
+    public class ConstructorDeclarationHandler : UstNodeHandler
+    {
+        private ConstructorDeclaration Model { get => (ConstructorDeclaration)UstNode; }
+
+        public ConstructorDeclarationHandler(CodeContext context,
+            ConstructorDeclarationSyntax syntaxNode)
+            : base(context, syntaxNode, new ConstructorDeclaration())
+        {
+            Model.Identifier = syntaxNode.Identifier.ToString();
+            SetMetaData(syntaxNode);
+        }
+
+        private void SetMetaData(ConstructorDeclarationSyntax syntaxNode)
+        {
+            foreach (var parameter in syntaxNode.ParameterList.Parameters)
+            {
+                var param = new Parameter
+                {
+                    Name = parameter.Identifier.Text
+                };
+
+                if (parameter.Type != null)
+                    param.Type = parameter.Type.ToString();
+
+                param.SemanticType =
+                    SemanticHelper.GetSemanticType(parameter.Type, SemanticModel);
+                Model.Parameters.Add(param);
+            }
+
+            Model.Modifiers = syntaxNode.Modifiers.ToString();
+
+            var methodSymbol = (IMethodSymbol)
+                (SemanticModel.GetSymbolInfo(syntaxNode).Symbol ??
+                 SemanticModel.GetDeclaredSymbol(syntaxNode));
+            if (methodSymbol == null) return;
+            SemanticHelper.AddMethodProperties(methodSymbol, Model.SemanticProperties);
+        }
+    }
+}

--- a/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/UstNodeHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/UstNodeHandler.cs
@@ -44,6 +44,10 @@ namespace Codelyzer.Analysis.CSharp.Handlers
             return symbol.ContainingAssembly != null && symbol.ContainingNamespace.Name != null
                 ? symbol.ContainingAssembly.Name.ToString().Trim() : string.Empty;
         }
+        protected string GetBaseTypOriginalDefinition(INamedTypeSymbol symbol)
+        {
+            return symbol.BaseType?.OriginalDefinition.ToString();
+        }
     }
 
 }

--- a/src/Analysis/Codelyzer.Analysis.Model/BaseMethodDeclaration.cs
+++ b/src/Analysis/Codelyzer.Analysis.Model/BaseMethodDeclaration.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Codelyzer.Analysis.Model
+{
+    public abstract class BaseMethodDeclaration : UstNode
+    {
+        [JsonProperty("modifiers", Order = 10)]
+        public string Modifiers { get; set; }
+
+        [JsonProperty("parameters", Order = 11)]
+        public List<Parameter> Parameters { get; set; }
+
+        [JsonProperty("semantic-properties", Order = 14)]
+        public UstList<string> SemanticProperties { get; set; }
+
+        protected BaseMethodDeclaration(string idName)
+            : base(idName)
+        {
+            Parameters = new UstList<Parameter>();
+            SemanticProperties = new UstList<string>();
+        }
+    }
+}

--- a/src/Analysis/Codelyzer.Analysis.Model/ClassDeclaration.cs
+++ b/src/Analysis/Codelyzer.Analysis.Model/ClassDeclaration.cs
@@ -7,6 +7,9 @@ namespace Codelyzer.Analysis.Model
         [JsonProperty("base-type", Order = 10)]
         public string BaseType { get; set; }
 
+        [JsonProperty("base-type-original-def", Order = 11)]
+        public string BaseTypeOriginalDefinition { get; set; }
+
         [JsonProperty("references", Order = 99)]
         public Reference Reference { get; set; }
         public string SemanticAssembly { get; set; }

--- a/src/Analysis/Codelyzer.Analysis.Model/ConstructorDeclaration.cs
+++ b/src/Analysis/Codelyzer.Analysis.Model/ConstructorDeclaration.cs
@@ -1,12 +1,10 @@
 ﻿namespace Codelyzer.Analysis.Model
 {
-    public class ConstructorDeclaration : MethodDeclaration
+    public class ConstructorDeclaration : BaseMethodDeclaration
     {
         public ConstructorDeclaration()
             : base(IdConstants.ConstructorIdName)
         {
-            Parameters = new UstList<Parameter>();
-            SemanticProperties = new UstList<string>();
         }
     }
 }

--- a/src/Analysis/Codelyzer.Analysis.Model/ConstructorDeclaration.cs
+++ b/src/Analysis/Codelyzer.Analysis.Model/ConstructorDeclaration.cs
@@ -1,18 +1,7 @@
-﻿using System.Collections.Generic;
-using Newtonsoft.Json;
- 
-namespace Codelyzer.Analysis.Model
+﻿namespace Codelyzer.Analysis.Model
 {
-    public class ConstructorDeclaration : UstNode
+    public class ConstructorDeclaration : MethodDeclaration
     {
-        [JsonProperty("modifiers", Order = 10)]
-        public string Modifiers { get; set; }
-
-        [JsonProperty("parameters", Order = 11)]
-        public List<Parameter> Parameters { get; set; }
-
-        [JsonProperty("semantic-properties", Order = 14)]
-        public UstList<string> SemanticProperties { get; set; }
         public ConstructorDeclaration()
             : base(IdConstants.ConstructorIdName)
         {

--- a/src/Analysis/Codelyzer.Analysis.Model/ConstructorDeclaration.cs
+++ b/src/Analysis/Codelyzer.Analysis.Model/ConstructorDeclaration.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+ 
+namespace Codelyzer.Analysis.Model
+{
+    public class ConstructorDeclaration : UstNode
+    {
+        [JsonProperty("modifiers", Order = 10)]
+        public string Modifiers { get; set; }
+
+        [JsonProperty("parameters", Order = 11)]
+        public List<Parameter> Parameters { get; set; }
+
+        [JsonProperty("semantic-properties", Order = 14)]
+        public UstList<string> SemanticProperties { get; set; }
+        public ConstructorDeclaration()
+            : base(IdConstants.ConstructorIdName)
+        {
+            Parameters = new UstList<Parameter>();
+            SemanticProperties = new UstList<string>();
+        }
+    }
+}

--- a/src/Analysis/Codelyzer.Analysis.Model/Extensions/UstNodeLinq.cs
+++ b/src/Analysis/Codelyzer.Analysis.Model/Extensions/UstNodeLinq.cs
@@ -46,6 +46,11 @@ namespace Codelyzer.Analysis.Model
             return GetNodes<MethodDeclaration>(node);
         }
 
+        public static UstList<ConstructorDeclaration> AllConstructors(this UstNode node)
+        {
+            return GetNodes<ConstructorDeclaration>(node);
+        }
+
         public static UstList<NamespaceDeclaration> AllNamespaces(this UstNode node)
         {
             return GetNodes<NamespaceDeclaration>(node);
@@ -73,15 +78,11 @@ namespace Codelyzer.Analysis.Model
                     {
                         nodes.Add((T)child);
                     }
-                    else
-                    {
-                        nodes.AddRange(GetNodes<T>(child));
-                    }
+                    nodes.AddRange(GetNodes<T>(child));
                 }
             }
 
             return nodes;
         }
-        
     }
 }

--- a/src/Analysis/Codelyzer.Analysis.Model/IdConstants.cs
+++ b/src/Analysis/Codelyzer.Analysis.Model/IdConstants.cs
@@ -28,5 +28,6 @@ namespace Codelyzer.Analysis.Model
 
         public const string AnnotationIdName = "annotation";
 
+        public const string ConstructorIdName = "constructor";
     }
 }

--- a/src/Analysis/Codelyzer.Analysis.Model/MethodDeclaration.cs
+++ b/src/Analysis/Codelyzer.Analysis.Model/MethodDeclaration.cs
@@ -1,35 +1,22 @@
-using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Codelyzer.Analysis.Model
 {
-    public class MethodDeclaration : UstNode
+    public class MethodDeclaration : BaseMethodDeclaration
     {
-        [JsonProperty("modifiers", Order = 10)]
-        public string Modifiers { get; set; }
-
-        [JsonProperty("parameters", Order = 11)] 
-        public List<Parameter> Parameters { get; set; }
-
         [JsonProperty("return-type", Order = 12)]
         public string ReturnType { get; set; }
         
         [JsonProperty("semantic-return-type", Order = 13)]
         public string SemanticReturnType { get; set; }
-        
-        [JsonProperty("semantic-properties", Order = 14)]
-        public UstList<string> SemanticProperties { get; set; }
+
         public MethodDeclaration()
             : base(IdConstants.MethodIdName)
         {
-            Parameters = new UstList<Parameter>();
-            SemanticProperties = new UstList<string>();
         }
         public MethodDeclaration(string idName)
             : base(idName)
         {
-            Parameters = new UstList<Parameter>();
-            SemanticProperties = new UstList<string>();
         }
     }
 }

--- a/src/Analysis/Codelyzer.Analysis.Model/MethodDeclaration.cs
+++ b/src/Analysis/Codelyzer.Analysis.Model/MethodDeclaration.cs
@@ -25,5 +25,11 @@ namespace Codelyzer.Analysis.Model
             Parameters = new UstList<Parameter>();
             SemanticProperties = new UstList<string>();
         }
+        public MethodDeclaration(string idName)
+            : base(idName)
+        {
+            Parameters = new UstList<Parameter>();
+            SemanticProperties = new UstList<string>();
+        }
     }
 }

--- a/src/Analysis/Codelyzer.Analysis/AnalyzerCLI.cs
+++ b/src/Analysis/Codelyzer.Analysis/AnalyzerCLI.cs
@@ -59,8 +59,7 @@ namespace Codelyzer.Analysis
                         FilePath = o.SolutionPath;
                     }
 
-                    String jsonData;
-                    if (o.JsonFilePath != null && o.JsonFilePath.Length != 0)
+                    if (!string.IsNullOrEmpty(o.JsonFilePath))
                     {
                         Configuration.ExportSettings.GenerateJsonOutput = true;
                         Configuration.ExportSettings.OutputPath = o.JsonFilePath;

--- a/src/Analysis/Codelyzer.Analysis/CSharpCodeAnalyzer.cs
+++ b/src/Analysis/Codelyzer.Analysis/CSharpCodeAnalyzer.cs
@@ -57,7 +57,7 @@ namespace Codelyzer.Analysis
 
             foreach (var projectBuildResult in projectBuildResults)
             {
-                var workspaceResult = await AnalyzeProject(projectBuildResult);
+                var workspaceResult = await Task.Run(() => AnalyzeProject(projectBuildResult));
                 workspaceResult.ProjectGuid = projectBuildResult.ProjectGuid;
                 workspaceResult.ProjectType = projectBuildResult.ProjectType;
                 workspaceResults.Add(workspaceResult);
@@ -95,7 +95,7 @@ namespace Codelyzer.Analysis
             }
         }
 
-        private async Task<ProjectWorkspace> AnalyzeProject(ProjectBuildResult projectResult)
+        private ProjectWorkspace AnalyzeProject(ProjectBuildResult projectResult)
         {
             Logger.LogDebug("Analyzing the project: " + projectResult.ProjectPath);
             ProjectWorkspace workspace = new ProjectWorkspace(projectResult.ProjectPath)

--- a/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
@@ -12,7 +12,7 @@ namespace Codelyzer.Analysis.Tests
 {
     //Implementations
 
-    [TestFixture()]
+    [TestFixture]
     [NonParallelizable]
     public class AwsAnalyzerTests : AwsBaseTest
     {
@@ -21,8 +21,8 @@ namespace Codelyzer.Analysis.Tests
         [SetUp]
         public void Setup()
         {
-            Setup(this.GetType());
-            tempDir = GetTstPath(Path.Combine(new string[] { "Projects", "Temp" }));
+            Setup(GetType());
+            tempDir = GetTstPath(Path.Combine(new [] { "Projects", "Temp" }));
             DownloadTestProjects();
         }
 
@@ -64,11 +64,10 @@ namespace Codelyzer.Analysis.Tests
         }
 
         [Test]
-        public async Task TestCli()
+        public void TestCli()
         {
             string mvcMusicStorePath = Directory.EnumerateFiles(tempDir, "MvcMusicStore.sln", SearchOption.AllDirectories).FirstOrDefault();
-            var sampleFilePath = GetSrcPath(Path.Combine("Analysis", "Codelyzer.Analysis", "sample_input.json"));
-            string[] args = new string[] { "-p", mvcMusicStorePath };
+            string[] args = { "-p", mvcMusicStorePath };
             AnalyzerCLI cli = new AnalyzerCLI();
             cli.HandleCommand(args);
             Assert.NotNull(cli);
@@ -80,7 +79,7 @@ namespace Codelyzer.Analysis.Tests
         [Test]
         public async Task TestAnalyzer()
         {
-            string projectPath = string.Concat(GetTstPath(Path.Combine(new string[] { "Projects", "CodelyzerDummy", "CodelyzerDummy" })), ".csproj");
+            string projectPath = string.Concat(GetTstPath(Path.Combine(new [] { "Projects", "CodelyzerDummy", "CodelyzerDummy" })), ".csproj");
 
             AnalyzerConfiguration configuration = new AnalyzerConfiguration(LanguageOptions.CSharp)
             {
@@ -163,6 +162,7 @@ namespace Codelyzer.Analysis.Tests
             Assert.AreEqual(expressionStatements.Count, 51);
             Assert.AreEqual(invocationExpressions.Count, 41);
             Assert.AreEqual(literalExpressions.Count, 10);
+            Assert.AreEqual(methodDeclarations.Count, 6);
             Assert.AreEqual(namespaceDeclarations.Count, 1);
             Assert.AreEqual(objectCreationExpressions.Count, 0);
             Assert.AreEqual(usingDirectives.Count, 10);

--- a/tst/Projects/CodelyzerDummy/Class2.cs
+++ b/tst/Projects/CodelyzerDummy/Class2.cs
@@ -1,0 +1,33 @@
+﻿namespace CodelyzerDummy
+{
+    public class Class2
+    {
+        private readonly int _someInt;
+        private readonly string _someStr;
+
+        public Class2(int someInt, string someStr)
+        {
+            _someInt = someInt;
+            _someStr = someStr;
+        }
+
+        public void TestMethod()
+        {
+            FirstMethod().ChainedMethod();
+        }
+
+        private Class2 FirstMethod()
+        {
+            return new Class2(0, "");
+        }
+
+        private Class2 ChainedMethod()
+        {
+            return new Class2(0, "");
+        }
+
+        public class NestedClass
+        {
+        }
+    }
+}


### PR DESCRIPTION
### Issue #, if available:
N/A

### Description of changes:
* In `ClassDeclaration` model, added `BaseTypeOriginalDefinition` property to help identify generic base classes. 
  * Example: 
If a BaseType returns `System.Collections.Generic.List<MyConcreteClass>`, then BaseTypeOriginalDefinition returns `System.Collections.Generic.List<T>`
* Added support for identifying `ConstructorDeclaration` nodes
* Updated `GetNodes<T>()` method's traversal behavior to allow discovery of nested nodes of the same type (e.g. nested class declarations or chained method invocations)
* Created unit tests using new test project to support the above changes in business logic
* Updated existing unit test assertion to include Block nodes that are children of Constructor nodes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
