### PR TITLE
Support return statements

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -32,7 +32,7 @@ jobs:
       run: dotnet pack --configuration Release --no-restore -o dist src/Codelyzer.sln
     - name: Install Sleet
       if: ${{ github.event_name == 'push' }}
-      run: dotnet tool install -g sleet
+      run: dotnet tool install -g sleet --version 3.2.0
     - name: "Configure AWS Credentials"
       if: ${{ github.event_name == 'push' }}
       uses: aws-actions/configure-aws-credentials@v1

--- a/src/Analysis/Codelyzer.Analysis.CSharp/CSharpRoslynProcessor.cs
+++ b/src/Analysis/Codelyzer.Analysis.CSharp/CSharpRoslynProcessor.cs
@@ -254,13 +254,16 @@ namespace Codelyzer.Analysis.CSharp
                 }
             }
 
-            var returnStatements = node.DescendantNodes().OfType<ReturnStatementSyntax>();
-            foreach (var returnStatement in returnStatements)
+            if (MetaDataSettings.ReturnStatements)
             {
-                var r = VisitReturnStatement((ReturnStatementSyntax)returnStatement);
-                if (r != null)
+                var returnStatements = node.DescendantNodes().OfType<ReturnStatementSyntax>();
+                foreach (var returnStatement in returnStatements)
                 {
-                    handler.UstNode.Children.Add(r);
+                    var r = VisitReturnStatement((ReturnStatementSyntax)returnStatement);
+                    if (r != null)
+                    {
+                        handler.UstNode.Children.Add(r);
+                    }
                 }
             }
 
@@ -311,13 +314,16 @@ namespace Codelyzer.Analysis.CSharp
                 }
             }
 
-            var returnStatements = node.DescendantNodes().OfType<ReturnStatementSyntax>();
-            foreach (var returnStatement in returnStatements)
+            if (MetaDataSettings.ReturnStatements)
             {
-                var r = VisitReturnStatement((ReturnStatementSyntax)returnStatement);
-                if (r != null)
+                var returnStatements = node.DescendantNodes().OfType<ReturnStatementSyntax>();
+                foreach (var returnStatement in returnStatements)
                 {
-                    handler.UstNode.Children.Add(r);
+                    var r = VisitReturnStatement((ReturnStatementSyntax)returnStatement);
+                    if (r != null)
+                    {
+                        handler.UstNode.Children.Add(r);
+                    }
                 }
             }
 

--- a/src/Analysis/Codelyzer.Analysis.CSharp/CSharpRoslynProcessor.cs
+++ b/src/Analysis/Codelyzer.Analysis.CSharp/CSharpRoslynProcessor.cs
@@ -314,19 +314,6 @@ namespace Codelyzer.Analysis.CSharp
                 }
             }
 
-            if (MetaDataSettings.ReturnStatements)
-            {
-                var returnStatements = node.DescendantNodes().OfType<ReturnStatementSyntax>();
-                foreach (var returnStatement in returnStatements)
-                {
-                    var r = VisitReturnStatement((ReturnStatementSyntax)returnStatement);
-                    if (r != null)
-                    {
-                        handler.UstNode.Children.Add(r);
-                    }
-                }
-            }
-
             var objCreations = node.DescendantNodes().OfType<ObjectCreationExpressionSyntax>();
             foreach (var expression in objCreations)
             {

--- a/src/Analysis/Codelyzer.Analysis.CSharp/CSharpRoslynProcessor.cs
+++ b/src/Analysis/Codelyzer.Analysis.CSharp/CSharpRoslynProcessor.cs
@@ -233,6 +233,13 @@ namespace Codelyzer.Analysis.CSharp
             return handler.UstNode;
         }
 
+        public override UstNode VisitReturnStatement(ReturnStatementSyntax node)
+        {
+            ReturnStatementHandler handler = new ReturnStatementHandler(context, node);
+
+            return handler.UstNode;
+        }
+
         public override UstNode VisitBlock(BlockSyntax node)
         {
             BlockStatementHandler handler = new BlockStatementHandler(context, node);
@@ -244,6 +251,16 @@ namespace Codelyzer.Analysis.CSharp
                 foreach (var expression in expressions)
                 {
                     result.Children.Add(VisitInvocationExpression((InvocationExpressionSyntax)expression));
+                }
+            }
+
+            var returnStatements = node.DescendantNodes().OfType<ReturnStatementSyntax>();
+            foreach (var returnStatement in returnStatements)
+            {
+                var r = VisitReturnStatement((ReturnStatementSyntax)returnStatement);
+                if (r != null)
+                {
+                    handler.UstNode.Children.Add(r);
                 }
             }
 
@@ -291,6 +308,16 @@ namespace Codelyzer.Analysis.CSharp
                 foreach (var expression in expressions)
                 {
                     result.Children.Add(VisitInvocationExpression((InvocationExpressionSyntax)expression));
+                }
+            }
+
+            var returnStatements = node.DescendantNodes().OfType<ReturnStatementSyntax>();
+            foreach (var returnStatement in returnStatements)
+            {
+                var r = VisitReturnStatement((ReturnStatementSyntax)returnStatement);
+                if (r != null)
+                {
+                    handler.UstNode.Children.Add(r);
                 }
             }
 

--- a/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/ReturnStatementHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/ReturnStatementHandler.cs
@@ -12,14 +12,11 @@ namespace Codelyzer.Analysis.CSharp.Handlers
             ReturnStatementSyntax syntaxNode)
             : base(context, syntaxNode, new ReturnStatement())
         {
-            Model.Identifier = null;
-            SetMetaData(syntaxNode);
-        }
-
-        private void SetMetaData(ReturnStatementSyntax syntaxNode)
-        {
             if (syntaxNode.Expression != null)
+            {
+                Model.Identifier = syntaxNode.Expression.ToString();
                 Model.SemanticReturnType = SemanticHelper.GetSemanticType(syntaxNode.Expression, SemanticModel);
+            }
         }
     }
 }

--- a/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/ReturnStatementHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/ReturnStatementHandler.cs
@@ -1,0 +1,25 @@
+using Codelyzer.Analysis.Common;
+using Codelyzer.Analysis.Model;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Codelyzer.Analysis.CSharp.Handlers
+{
+    public class ReturnStatementHandler : UstNodeHandler
+    {
+        private ReturnStatement Model { get => (ReturnStatement)UstNode; }
+
+        public ReturnStatementHandler(CodeContext context, 
+            ReturnStatementSyntax syntaxNode)
+            : base(context, syntaxNode, new ReturnStatement())
+        {
+            Model.Identifier = null;
+            SetMetaData(syntaxNode);
+        }
+
+        private void SetMetaData(ReturnStatementSyntax syntaxNode)
+        {
+            if (syntaxNode.Expression != null)
+                Model.SemanticReturnType = SemanticHelper.GetSemanticType(syntaxNode.Expression, SemanticModel);
+        }
+    }
+}

--- a/src/Analysis/Codelyzer.Analysis.CSharp/SemanticHelper.cs
+++ b/src/Analysis/Codelyzer.Analysis.CSharp/SemanticHelper.cs
@@ -14,17 +14,17 @@ namespace Codelyzer.Analysis.CSharp
         /// <summary>
         /// Gets name of type from TypeSyntax
         /// </summary>
-        /// <param name="parameter">The TypeSyntax parameter to get info about</param>
+        /// <param name="typeSyntax">The TypeSyntax parameter to get info about</param>
         /// <param name="semanticModel">An instance of the semantic model</param>
         /// <returns>Name of the type</returns>
-        public static string GetSemanticType(TypeSyntax parameter, 
+        public static string GetSemanticType(TypeSyntax typeSyntax, 
             SemanticModel semanticModel)
         {
             if (semanticModel == null) return null;
             
             string type = null;
 
-            var typeInfo = semanticModel.GetTypeInfo(parameter);
+            var typeInfo = semanticModel.GetTypeInfo(typeSyntax);
             if (typeInfo.Type != null)
             {
                 type = typeInfo.Type.Name;
@@ -36,7 +36,7 @@ namespace Codelyzer.Analysis.CSharp
         /// <summary>
         /// Gets name of type from ExpressionSyntax
         /// </summary>
-        /// <param name="parameter">The ExpressionSyntax to get info about</param>
+        /// <param name="expressionSyntax">The ExpressionSyntax to get info about</param>
         /// <param name="semanticModel">An instance of the semantic model</param>
         /// <returns>Name of the type</returns>
         public static string GetSemanticType(ExpressionSyntax expressionSyntax, 
@@ -58,7 +58,7 @@ namespace Codelyzer.Analysis.CSharp
         /// <summary>
         /// Gets name of type from IdentifierNameSyntax
         /// </summary>
-        /// <param name="parameter">The IdentifierNameSyntax to get info about</param>
+        /// <param name="identifierNameSyntax">The IdentifierNameSyntax to get info about</param>
         /// <param name="semanticModel">An instance of the semantic model</param>
         /// <returns>Name of the type</returns>
         public static string GetSemanticType(IdentifierNameSyntax identifierNameSyntax,

--- a/src/Analysis/Codelyzer.Analysis.Common/AnalyzerConfiguration.cs
+++ b/src/Analysis/Codelyzer.Analysis.Common/AnalyzerConfiguration.cs
@@ -49,7 +49,7 @@ namespace Codelyzer.Analysis
         public bool InterfaceDeclarations = false;
         public bool EnumDeclarations = false;
         public bool StructDeclarations = false;
-        public bool ReturnStatements = true;
+        public bool ReturnStatements = false;
         public bool GenerateBinFiles = false;
     }
 }

--- a/src/Analysis/Codelyzer.Analysis.Common/AnalyzerConfiguration.cs
+++ b/src/Analysis/Codelyzer.Analysis.Common/AnalyzerConfiguration.cs
@@ -49,6 +49,7 @@ namespace Codelyzer.Analysis
         public bool InterfaceDeclarations = false;
         public bool EnumDeclarations = false;
         public bool StructDeclarations = false;
+        public bool ReturnStatements = true;
         public bool GenerateBinFiles = false;
     }
 }

--- a/src/Analysis/Codelyzer.Analysis.Model/Extensions/UstNodeLinq.cs
+++ b/src/Analysis/Codelyzer.Analysis.Model/Extensions/UstNodeLinq.cs
@@ -4,6 +4,11 @@ namespace Codelyzer.Analysis.Model
 {
     public static class UstNodeLinq
     {
+        public static UstList<Annotation> AllAnnotations(this UstNode node)
+        {
+            return GetNodes<Annotation>(node);
+        }
+
         public static UstList<BlockStatement> AllBlockStatements(this UstNode node)
         {
             return GetNodes<BlockStatement>(node);
@@ -49,6 +54,11 @@ namespace Codelyzer.Analysis.Model
         public static UstList<MethodDeclaration> AllMethods(this UstNode node)
         {
             return GetNodes<MethodDeclaration>(node);
+        }
+
+        public static UstList<ReturnStatement> AllReturnStatements(this UstNode node)
+        {
+            return GetNodes<ReturnStatement>(node);
         }
 
         public static UstList<ConstructorDeclaration> AllConstructors(this UstNode node)

--- a/src/Analysis/Codelyzer.Analysis.Model/IdConstants.cs
+++ b/src/Analysis/Codelyzer.Analysis.Model/IdConstants.cs
@@ -17,6 +17,8 @@ namespace Codelyzer.Analysis.Model
         public const string InterfaceIdName = "interface";
 
         public const string MethodIdName = "method";
+
+        public const string ReturnStatementIdName = "return-statement";
         
         public const string BodyIdName = "body";
 

--- a/src/Analysis/Codelyzer.Analysis.Model/ReturnStatement.cs
+++ b/src/Analysis/Codelyzer.Analysis.Model/ReturnStatement.cs
@@ -1,0 +1,20 @@
+using Newtonsoft.Json;
+
+namespace Codelyzer.Analysis.Model
+{
+    public class ReturnStatement : UstNode
+    {
+        [JsonProperty("semantic-return-type", Order = 10)]
+        public string SemanticReturnType { get; set; }
+
+        public ReturnStatement()
+            : base(IdConstants.ReturnStatementIdName)
+        {
+        }
+
+        public ReturnStatement(string idName)
+            : base(idName)
+        {
+        }
+    }
+}

--- a/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
@@ -133,7 +133,8 @@ namespace Codelyzer.Analysis.Tests
                     LocationData = false,
                     ReferenceData = true,
                     InterfaceDeclarations = true,
-                    GenerateBinFiles = true
+                    GenerateBinFiles = true,
+                    ReturnStatements = true
                 }
             };
             CodeAnalyzer analyzer = CodeAnalyzerFactory.GetAnalyzer(configuration, NullLogger.Instance);

--- a/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
@@ -42,7 +42,7 @@ namespace Codelyzer.Analysis.Tests
             //{
             //    Directory.Delete(destDir, true);
             //}
-
+            //Library\Microsoft\Windows\Application Experience.
             DownloadFromGitHub(@"https://github.com/FabianGosebrink/ASPNET-WebAPI-Sample/archive/671a629cab0382ecd6dec4833b3868f96f89da50.zip", "ASPNET-WebAPI-Sample-671a629cab0382ecd6dec4833b3868f96f89da50");
             DownloadFromGitHub(@"https://github.com/Duikmeester/MvcMusicStore/archive/e274968f2827c04cfefbe6493f0a784473f83f80.zip", "MvcMusicStore-e274968f2827c04cfefbe6493f0a784473f83f80");
             DownloadFromGitHub(@"https://github.com/nopSolutions/nopCommerce/archive/73567858b3e3ef281d1433d7ac79295ebed47ee6.zip", "nopCommerce-73567858b3e3ef281d1433d7ac79295ebed47ee6");
@@ -141,10 +141,10 @@ namespace Codelyzer.Analysis.Tests
             Assert.True(result != null);
 
             //Project has 16 nuget references and 19 framework/dll references:
-            Assert.AreEqual(result.ProjectResult.ExternalReferences.NugetReferences.Count, 16);
-            Assert.AreEqual(result.ProjectResult.ExternalReferences.SdkReferences.Count, 19);
+            Assert.AreEqual(16, result.ProjectResult.ExternalReferences.NugetReferences.Count);
+            Assert.AreEqual(19, result.ProjectResult.ExternalReferences.SdkReferences.Count);
 
-            Assert.AreEqual(result.ProjectResult.SourceFiles.Count, 10);
+            Assert.AreEqual(10, result.ProjectResult.SourceFiles.Count);
 
             var houseController = result.ProjectResult.SourceFileResults.Where(f => f.FilePath.EndsWith("HouseController.cs")).FirstOrDefault();
             Assert.NotNull(houseController);
@@ -158,22 +158,26 @@ namespace Codelyzer.Analysis.Tests
             var invocationExpressions = houseController.AllInvocationExpressions();
             var literalExpressions = houseController.AllLiterals();
             var methodDeclarations = houseController.AllMethods();
+            var returnStatements = houseController.AllReturnStatements();
+            var annotations = houseController.AllAnnotations();
             var namespaceDeclarations = houseController.AllNamespaces();
             var objectCreationExpressions = houseController.AllObjectCreationExpressions();
             var usingDirectives = houseController.AllUsingDirectives();
             var interfaces = ihouseRepository.AllInterfaces();
 
 
-            Assert.AreEqual(blockStatements.Count, 7);
-            Assert.AreEqual(classDeclarations.Count, 1);
-            Assert.AreEqual(expressionStatements.Count, 51);
-            Assert.AreEqual(invocationExpressions.Count, 41);
-            Assert.AreEqual(literalExpressions.Count, 10);
-            Assert.AreEqual(methodDeclarations.Count, 6);
-            Assert.AreEqual(namespaceDeclarations.Count, 1);
-            Assert.AreEqual(objectCreationExpressions.Count, 0);
-            Assert.AreEqual(usingDirectives.Count, 10);
-            Assert.AreEqual(interfaces.Count, 1);
+            Assert.AreEqual(7, blockStatements.Count);
+            Assert.AreEqual(1, classDeclarations.Count);
+            Assert.AreEqual(51, expressionStatements.Count);
+            Assert.AreEqual(41, invocationExpressions.Count);
+            Assert.AreEqual(10, literalExpressions.Count);
+            Assert.AreEqual(6, methodDeclarations.Count);
+            Assert.AreEqual(16, returnStatements.Count);
+            Assert.AreEqual(17, annotations.Count);
+            Assert.AreEqual(1, namespaceDeclarations.Count);
+            Assert.AreEqual(0, objectCreationExpressions.Count);
+            Assert.AreEqual(10, usingDirectives.Count);
+            Assert.AreEqual(1, interfaces.Count);
 
             var dllFiles = Directory.EnumerateFiles(Path.Combine(result.ProjectResult.ProjectRootPath, "bin"), "*.dll");
             Assert.AreEqual(dllFiles.Count(), 16);
@@ -207,11 +211,11 @@ namespace Codelyzer.Analysis.Tests
             using var result = (await analyzer.AnalyzeSolution(solutionPath)).FirstOrDefault();
             Assert.True(result != null);
 
-            Assert.AreEqual(result.ProjectResult.SourceFiles.Count, 28);
+            Assert.AreEqual(28, result.ProjectResult.SourceFiles.Count);
 
             //Project has 16 nuget references and 19 framework/dll references:
-            Assert.AreEqual(result.ProjectResult.ExternalReferences.NugetReferences.Count, 29);
-            Assert.AreEqual(result.ProjectResult.ExternalReferences.SdkReferences.Count, 24);
+            Assert.AreEqual(29, result.ProjectResult.ExternalReferences.NugetReferences.Count);
+            Assert.AreEqual(24, result.ProjectResult.ExternalReferences.SdkReferences.Count);
 
             var homeController = result.ProjectResult.SourceFileResults.Where(f => f.FilePath.EndsWith("HomeController.cs")).FirstOrDefault();
             Assert.NotNull(homeController);
@@ -226,10 +230,10 @@ namespace Codelyzer.Analysis.Tests
             var methodDeclarations = classDeclaration.Children.OfType<Model.MethodDeclaration>();
 
             //HouseController has 3 identifiers declared within the class declaration:
-            Assert.AreEqual(declarationNodes.Count(), 4);
+            Assert.AreEqual(4, declarationNodes.Count());
 
             //It has 2 method declarations
-            Assert.AreEqual(methodDeclarations.Count(), 2);
+            Assert.AreEqual(2, methodDeclarations.Count());
         }
 
         [Test]
@@ -313,9 +317,9 @@ namespace Codelyzer.Analysis.Tests
             var structDeclarations = results.Sum(r => r.ProjectResult.SourceFileResults.Where(s => s.AllStructDeclarations().Count > 0).Sum(s => s.AllStructDeclarations().Count));
             var arrowClauseStatements = results.Sum(r => r.ProjectResult.SourceFileResults.Where(s => s.AllArrowExpressionClauses().Count > 0).Sum(s => s.AllArrowExpressionClauses().Count));
 
-            Assert.AreEqual(enumDeclarations, 80);
-            Assert.AreEqual(structDeclarations, 1);
-            Assert.AreEqual(arrowClauseStatements, 2);
+            Assert.AreEqual(80, enumDeclarations);
+            Assert.AreEqual(1, structDeclarations);
+            Assert.AreEqual(2, arrowClauseStatements);
 
             results.ForEach(r => r.Dispose());
         }

--- a/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
@@ -42,7 +42,7 @@ namespace Codelyzer.Analysis.Tests
             //{
             //    Directory.Delete(destDir, true);
             //}
-            //Library\Microsoft\Windows\Application Experience.
+
             DownloadFromGitHub(@"https://github.com/FabianGosebrink/ASPNET-WebAPI-Sample/archive/671a629cab0382ecd6dec4833b3868f96f89da50.zip", "ASPNET-WebAPI-Sample-671a629cab0382ecd6dec4833b3868f96f89da50");
             DownloadFromGitHub(@"https://github.com/Duikmeester/MvcMusicStore/archive/e274968f2827c04cfefbe6493f0a784473f83f80.zip", "MvcMusicStore-e274968f2827c04cfefbe6493f0a784473f83f80");
             DownloadFromGitHub(@"https://github.com/nopSolutions/nopCommerce/archive/73567858b3e3ef281d1433d7ac79295ebed47ee6.zip", "nopCommerce-73567858b3e3ef281d1433d7ac79295ebed47ee6");


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* add support for `ReturnStatementSyntax` nodes
* we look for Return Statements wherever InvocationExpressions are looked for (inside `MethodDeclaration` and `ArrowExpression` nodes)
* add linq functions to find `ReturnStatement` and `Annotation` nodes
* refactored some `Assert` statements where the `Actual` and `Expected` values were swapped (this had no effect on functionality, but it did negatively affect test failure messages)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
