### PR TITLE
add support for argument nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ bld/
 *.VisualState.xml
 TestResult.xml
 
+# Test project directory
+**/Projects/Temp/
+
 # Build Results of an ATL Project
 [Dd]ebugPS/
 [Rr]eleasePS/

--- a/src/Analysis/Codelyzer.Analysis.CSharp/CSharpRoslynProcessor.cs
+++ b/src/Analysis/Codelyzer.Analysis.CSharp/CSharpRoslynProcessor.cs
@@ -17,6 +17,7 @@ namespace Codelyzer.Analysis.CSharp
     /// </summary>
     public class CSharpRoslynProcessor : CSharpSyntaxVisitor<UstNode>, IDisposable
     {
+        private readonly Dictionary<string, Func<ExpressionSyntax, UstNode>> _expressionSyntaxToVisitMethodMap;
         private CodeContext _context;
         protected SemanticModel SemanticModel { get => _context.SemanticModel; }
         protected SyntaxTree SyntaxTree { get => _context.SyntaxTree; }
@@ -27,6 +28,7 @@ namespace Codelyzer.Analysis.CSharp
         public CSharpRoslynProcessor(CodeContext context)
         {
             _context = context;
+            _expressionSyntaxToVisitMethodMap = GetSyntaxNodeToVisitMethodMap();
         }
 
         /// <summary>
@@ -175,6 +177,15 @@ namespace Codelyzer.Analysis.CSharp
             return base.VisitExpressionStatement(node);
         }
 
+        private UstNode VisitExpressionSyntax(ExpressionSyntax node)
+        {
+            if (node == null) return null;
+
+            return _expressionSyntaxToVisitMethodMap.TryGetValue(node.GetType().Name, out var visitMethod)
+                ? visitMethod.Invoke(node)
+                : null;
+        }
+
         public override UstNode VisitLiteralExpression(LiteralExpressionSyntax node)
         {
             if (!MetaDataSettings.LiteralExpressions) return null;
@@ -190,6 +201,18 @@ namespace Codelyzer.Analysis.CSharp
 
             InvocationExpressionHandler handler = new InvocationExpressionHandler(_context, node);
             HandleReferences(((InvocationExpression)handler.UstNode).Reference);
+
+            AddArgumentNodesToList(node, handler.UstNode.Children);
+
+            return handler.UstNode;
+        }
+
+        public override UstNode VisitArgument(ArgumentSyntax node)
+        {
+            if (!MetaDataSettings.InvocationArguments) return null;
+
+            ArgumentHandler handler = new ArgumentHandler(_context, node);
+            handler.UstNode.Children.Add(VisitExpressionSyntax(node.Expression));
 
             return handler.UstNode;
         }
@@ -301,6 +324,17 @@ namespace Codelyzer.Analysis.CSharp
             }
         }
 
+        private void AddArgumentNodesToList(InvocationExpressionSyntax node, List<UstNode> nodeList)
+        {
+            if (MetaDataSettings.InvocationArguments)
+            {
+                foreach (var argument in node.ArgumentList.Arguments)
+                {
+                    nodeList.Add(VisitArgument(argument));
+                }
+            }
+        }
+
         private void AddMethodBodyNodesToList(BaseMethodDeclarationSyntax node, List<UstNode> nodeList)
         {
             if (node.Body != null)
@@ -396,6 +430,28 @@ namespace Codelyzer.Analysis.CSharp
                 Logger.LogError(ex, node.ToString());
                 return null;
             }
+        }
+
+        /// <summary>
+        /// Some SyntaxNodes have properties of type ExpressionSyntax that we want to analyze. In those cases,
+        /// we can use this function to map implementation types of ExpressionSyntax to the correct Visit*()
+        /// function.
+        ///
+        /// Notes:
+        ///     - See full list of ExpressionSyntax nodes <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.csharp.syntax.expressionsyntax?view=roslyn-dotnet#derived:~:text=ExpressionSyntax-,Derived,Microsoft.CodeAnalysis.CSharp.Syntax.WithExpressionSyntax,-Properties">here</see>
+        ///     - TODO: Continue updating this map when support is added for a new ExpressionSyntax type
+        /// </summary>
+        /// <returns>Dictionary that maps an implementation type to the corresponding Visit*() method</returns>
+        private Dictionary<string, Func<ExpressionSyntax, UstNode>> GetSyntaxNodeToVisitMethodMap()
+        {
+            return new Dictionary<string, Func<ExpressionSyntax, UstNode>>
+            {
+                {nameof(IdentifierNameSyntax), node => VisitIdentifierName((IdentifierNameSyntax)node)},
+                {nameof(InvocationExpressionSyntax), node => VisitInvocationExpression((InvocationExpressionSyntax)node)},
+                {nameof(LiteralExpressionSyntax), node => VisitLiteralExpression((LiteralExpressionSyntax)node)},
+                {nameof(ObjectCreationExpressionSyntax), node => VisitObjectCreationExpression((ObjectCreationExpressionSyntax)node)},
+                {nameof(SimpleLambdaExpressionSyntax), node => VisitSimpleLambdaExpression((SimpleLambdaExpressionSyntax)node)},
+            };
         }
     }
 }

--- a/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/ArgumentHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/ArgumentHandler.cs
@@ -1,0 +1,19 @@
+using Codelyzer.Analysis.Common;
+using Codelyzer.Analysis.Model;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Codelyzer.Analysis.CSharp.Handlers
+{
+    public class ArgumentHandler : UstNodeHandler
+    {
+        private Argument Model { get => (Argument)UstNode; }
+
+        public ArgumentHandler(CodeContext context,
+            ArgumentSyntax syntaxNode)
+            : base(context, syntaxNode, new Argument())
+        {
+            Model.Identifier = syntaxNode.Expression.ToString();
+            Model.SemanticType = SemanticHelper.GetSemanticType(syntaxNode.Expression, SemanticModel);
+        }
+    }
+}

--- a/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/InvocationExpressionHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/InvocationExpressionHandler.cs
@@ -38,6 +38,15 @@ namespace Codelyzer.Analysis.CSharp.Handlers
 
             foreach (var argumentSyntax in syntaxNode.ArgumentList.Arguments)
             {
+                Parameter parameter = new Parameter();
+                if (argumentSyntax.Expression != null)
+                    parameter.Name = argumentSyntax.Expression.ToString();
+
+                parameter.SemanticType =
+                    SemanticHelper.GetSemanticType(argumentSyntax.Expression, SemanticModel);
+
+                Model.Parameters.Add(parameter);
+
                 var argument = new Argument
                 {
                     Identifier = argumentSyntax.Expression.ToString(),

--- a/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/InvocationExpressionHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/InvocationExpressionHandler.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text.RegularExpressions;
 using Codelyzer.Analysis.Common;
 using Codelyzer.Analysis.Model;
 using Microsoft.CodeAnalysis;
@@ -41,12 +38,13 @@ namespace Codelyzer.Analysis.CSharp.Handlers
 
             foreach (var argumentSyntax in syntaxNode.ArgumentList.Arguments)
             {
-                Parameter parameter = new Parameter();
-                if (argumentSyntax.Expression != null)
-                    parameter.Name = argumentSyntax.Expression.ToString();
+                var argument = new Argument
+                {
+                    Identifier = argumentSyntax.Expression.ToString(),
+                    SemanticType = SemanticHelper.GetSemanticType(argumentSyntax.Expression, SemanticModel)
+                };
 
-                parameter.SemanticType =
-                    SemanticHelper.GetSemanticType(argumentSyntax.Expression, SemanticModel);
+                Model.Arguments.Add(argument);
             }
 
             if (SemanticModel == null) return;

--- a/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/ObjectCreationExpressionHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/ObjectCreationExpressionHandler.cs
@@ -26,6 +26,17 @@ namespace Codelyzer.Analysis.CSharp.Handlers
             {
                 foreach (var argumentSyntax in syntaxNode.ArgumentList.Arguments)
                 {
+                    Parameter parameter = new Parameter();
+                    if (argumentSyntax.Expression != null)
+                        parameter.Name = argumentSyntax.Expression.ToString();
+
+                    parameter.SemanticType =
+                        SemanticHelper.GetSemanticType(argumentSyntax.Expression, SemanticModel);
+                    if (Model.Parameters != null)
+                    {
+                        Model.Parameters.Add(parameter);
+                    }
+
                     var argument = new Argument
                     {
                         Identifier = argumentSyntax.Expression.ToString(),

--- a/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/ObjectCreationExpressionHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/ObjectCreationExpressionHandler.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Text.RegularExpressions;
 using Codelyzer.Analysis.Common;
 using Codelyzer.Analysis.Model;
 using Microsoft.CodeAnalysis;
@@ -28,16 +26,12 @@ namespace Codelyzer.Analysis.CSharp.Handlers
             {
                 foreach (var argumentSyntax in syntaxNode.ArgumentList.Arguments)
                 {
-                    Parameter parameter = new Parameter();
-                    if (argumentSyntax.Expression != null)
-                        parameter.Name = argumentSyntax.Expression.ToString();
-                    
-                    parameter.SemanticType =
-                        SemanticHelper.GetSemanticType(argumentSyntax.Expression, SemanticModel);
-                    if (Model.Parameters != null)
+                    var argument = new Argument
                     {
-                        Model.Parameters.Add(parameter);
-                    }
+                        Identifier = argumentSyntax.Expression.ToString(),
+                        SemanticType = SemanticHelper.GetSemanticType(argumentSyntax.Expression, SemanticModel)
+                    };
+                    Model.Arguments.Add(argument);
                 }
             }
 

--- a/src/Analysis/Codelyzer.Analysis.Common/AnalyzerConfiguration.cs
+++ b/src/Analysis/Codelyzer.Analysis.Common/AnalyzerConfiguration.cs
@@ -1,7 +1,4 @@
 using Codelyzer.Analysis.Common;
-using Newtonsoft.Json.Serialization;
-using System;
-using System.Collections.Generic;
 
 namespace Codelyzer.Analysis
 {
@@ -50,6 +47,7 @@ namespace Codelyzer.Analysis
         public bool EnumDeclarations = false;
         public bool StructDeclarations = false;
         public bool ReturnStatements = false;
+        public bool InvocationArguments = false;
         public bool GenerateBinFiles = false;
     }
 }

--- a/src/Analysis/Codelyzer.Analysis.Model/Argument.cs
+++ b/src/Analysis/Codelyzer.Analysis.Model/Argument.cs
@@ -1,0 +1,15 @@
+using Newtonsoft.Json;
+
+namespace Codelyzer.Analysis.Model
+{
+    public class Argument : UstNode
+    {
+        [JsonProperty("semantic-type", Order = 10)]
+        public string SemanticType { get; set; }
+
+        public Argument()
+            : base(IdConstants.ArgumentIdName)
+        {
+        }
+    }
+}

--- a/src/Analysis/Codelyzer.Analysis.Model/Constants.cs
+++ b/src/Analysis/Codelyzer.Analysis.Model/Constants.cs
@@ -1,0 +1,9 @@
+﻿namespace Codelyzer.Analysis.Model
+{
+    internal class Constants
+    {
+        internal const bool ThrowErrorOnUse = true;
+        internal const bool DoNotThrowErrorOnUse = false;
+        internal const string ObsoleteParameterMessage = "Use Argument property instead. This property will be removed in a later version.";
+    }
+}

--- a/src/Analysis/Codelyzer.Analysis.Model/Extensions/UstNodeLinq.cs
+++ b/src/Analysis/Codelyzer.Analysis.Model/Extensions/UstNodeLinq.cs
@@ -90,9 +90,15 @@ namespace Codelyzer.Analysis.Model
         {
             return GetNodes<StructDeclaration>(node);
         }
+
         public static UstList<ArrowExpressionClause> AllArrowExpressionClauses(this UstNode node)
         {
             return GetNodes<ArrowExpressionClause>(node);
+        }
+
+        public static UstList<Argument> AllArguments(this UstNode node)
+        {
+            return GetNodes<Argument>(node);
         }
 
         private static UstList<T> GetNodes<T>(UstNode node) where T : UstNode

--- a/src/Analysis/Codelyzer.Analysis.Model/IdConstants.cs
+++ b/src/Analysis/Codelyzer.Analysis.Model/IdConstants.cs
@@ -39,5 +39,7 @@ namespace Codelyzer.Analysis.Model
         public const string EnumIdName = "enum";
 
         public const string StructIdName = "struct";
+
+        public const string ArgumentIdName = "argument";
     }
 }

--- a/src/Analysis/Codelyzer.Analysis.Model/InvocationExpression.cs
+++ b/src/Analysis/Codelyzer.Analysis.Model/InvocationExpression.cs
@@ -45,6 +45,8 @@ namespace Codelyzer.Analysis.Model
             : base(typeName)
         {
             SemanticProperties = new List<string>();
+            Arguments = new List<Argument>();
+            Reference = new Reference();
         }
         
         public InvocationExpression()

--- a/src/Analysis/Codelyzer.Analysis.Model/InvocationExpression.cs
+++ b/src/Analysis/Codelyzer.Analysis.Model/InvocationExpression.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
@@ -24,8 +23,8 @@ namespace Codelyzer.Analysis.Model
         [JsonProperty("semantic-method-signature", Order = 15)]
         public string SemanticMethodSignature { get; set; }
         
-        [JsonProperty("parameters", Order = 16)] 
-        public List<Parameter> Parameters { get; set; }
+        [JsonProperty("arguments", Order = 16)] 
+        public List<Argument> Arguments { get; set; }
         
         [JsonProperty("semantic-return-type", Order = 17)]
         public string SemanticReturnType { get; set; }
@@ -52,7 +51,7 @@ namespace Codelyzer.Analysis.Model
             : base(IdConstants.InvocationIdName)
         {
             SemanticProperties = new List<string>();
-            Parameters = new List<Parameter>();
+            Arguments = new List<Argument>();
             Reference = new Reference();
         }
     }

--- a/src/Analysis/Codelyzer.Analysis.Model/InvocationExpression.cs
+++ b/src/Analysis/Codelyzer.Analysis.Model/InvocationExpression.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
@@ -22,20 +23,24 @@ namespace Codelyzer.Analysis.Model
         
         [JsonProperty("semantic-method-signature", Order = 15)]
         public string SemanticMethodSignature { get; set; }
-        
-        [JsonProperty("arguments", Order = 16)] 
+
+        [Obsolete(Constants.ObsoleteParameterMessage, Constants.DoNotThrowErrorOnUse)]
+        [JsonProperty("parameters", Order = 30)]
+        public List<Parameter> Parameters { get; set; }
+
+        [JsonProperty("arguments", Order = 31)] 
         public List<Argument> Arguments { get; set; }
         
-        [JsonProperty("semantic-return-type", Order = 17)]
+        [JsonProperty("semantic-return-type", Order = 35)]
         public string SemanticReturnType { get; set; }
 
-        [JsonProperty("semantic-original-def", Order = 18)]
+        [JsonProperty("semantic-original-def", Order = 40)]
         public string SemanticOriginalDefinition { get; set; }
         
-        [JsonProperty("semantic-properties", Order = 19)]
+        [JsonProperty("semantic-properties", Order = 45)]
         public List<string> SemanticProperties { get; set; }
 
-        [JsonProperty("semantic-is-extension", Order = 20)]
+        [JsonProperty("semantic-is-extension", Order = 50)]
         public bool IsExtension { get; set; }
 
         [JsonProperty("references", Order = 99)]
@@ -45,6 +50,7 @@ namespace Codelyzer.Analysis.Model
             : base(typeName)
         {
             SemanticProperties = new List<string>();
+            Parameters = new List<Parameter>();
             Arguments = new List<Argument>();
             Reference = new Reference();
         }
@@ -53,6 +59,7 @@ namespace Codelyzer.Analysis.Model
             : base(IdConstants.InvocationIdName)
         {
             SemanticProperties = new List<string>();
+            Parameters = new List<Parameter>();
             Arguments = new List<Argument>();
             Reference = new Reference();
         }

--- a/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
@@ -22,7 +22,7 @@ namespace Codelyzer.Analysis.Tests
         public void Setup()
         {
             Setup(GetType());
-            tempDir = GetTstPath(Path.Combine(new [] { "Projects", "Temp" }));
+            tempDir = GetTstPath(Path.Combine(Constants.TempProjectDirectories));
             DownloadTestProjects();
         }
 

--- a/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
@@ -80,7 +80,7 @@ namespace Codelyzer.Analysis.Tests
         [Test]
         public async Task TestAnalyzer()
         {
-            string projectPath = string.Concat(GetTstPath(Path.Combine(new [] { "Projects", "CodelyzerDummy", "CodelyzerDummy" })), ".csproj");
+            string projectPath = string.Concat(GetTstPath(Path.Combine(new[] { "Projects", "CodelyzerDummy", "CodelyzerDummy" })), ".csproj");
 
             AnalyzerConfiguration configuration = new AnalyzerConfiguration(LanguageOptions.CSharp)
             {
@@ -134,7 +134,8 @@ namespace Codelyzer.Analysis.Tests
                     ReferenceData = true,
                     InterfaceDeclarations = true,
                     GenerateBinFiles = true,
-                    ReturnStatements = true
+                    ReturnStatements = true,
+                    InvocationArguments = true
                 }
             };
             CodeAnalyzer analyzer = CodeAnalyzerFactory.GetAnalyzer(configuration, NullLogger.Instance);
@@ -165,13 +166,12 @@ namespace Codelyzer.Analysis.Tests
             var objectCreationExpressions = houseController.AllObjectCreationExpressions();
             var usingDirectives = houseController.AllUsingDirectives();
             var interfaces = ihouseRepository.AllInterfaces();
-
-
+            var arguments = houseController.AllArguments();
             Assert.AreEqual(7, blockStatements.Count);
             Assert.AreEqual(1, classDeclarations.Count);
-            Assert.AreEqual(74, expressionStatements.Count);
-            Assert.AreEqual(63, invocationExpressions.Count);
-            Assert.AreEqual(11, literalExpressions.Count);
+            Assert.AreEqual(89, expressionStatements.Count);
+            Assert.AreEqual(75, invocationExpressions.Count);
+            Assert.AreEqual(14, literalExpressions.Count);
             Assert.AreEqual(6, methodDeclarations.Count);
             Assert.AreEqual(16, returnStatements.Count);
             Assert.AreEqual(17, annotations.Count);
@@ -179,6 +179,7 @@ namespace Codelyzer.Analysis.Tests
             Assert.AreEqual(0, objectCreationExpressions.Count);
             Assert.AreEqual(10, usingDirectives.Count);
             Assert.AreEqual(1, interfaces.Count);
+            Assert.AreEqual(63, arguments.Count);
 
             var dllFiles = Directory.EnumerateFiles(Path.Combine(result.ProjectResult.ProjectRootPath, "bin"), "*.dll");
             Assert.AreEqual(dllFiles.Count(), 16);

--- a/tst/Codelyzer.Analysis.Tests/Constants.cs
+++ b/tst/Codelyzer.Analysis.Tests/Constants.cs
@@ -1,0 +1,9 @@
+﻿namespace Codelyzer.Analysis.Tests
+{
+    internal class Constants
+    {
+        // Do not change these values without updating the corresponding line in .gitignore:  **/Projects/Temp
+        // This is to prevent test projects from being picked up in git after failed unit tests.
+        internal static readonly string[] TempProjectDirectories = { "Projects", "Temp" };
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/codelyzer/issues/27

*Description of changes:*
* Add support for `ArgumentSyntax` nodes
* For `InvocationExpression` and `ObjectCreationExpression` nodes, `Parameter` objects were replaced by `Argument` objects (semantically speaking, parameters are used in method declarations and arguments are used in invocations)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
