### PR TITLE
Issue 50- Add support for AttributeArgument nodes

### DIFF
--- a/src/Analysis/Codelyzer.Analysis.CSharp/CSharpRoslynProcessor.cs
+++ b/src/Analysis/Codelyzer.Analysis.CSharp/CSharpRoslynProcessor.cs
@@ -167,6 +167,13 @@ namespace Codelyzer.Analysis.CSharp
             HandleReferences(((Annotation)handler.UstNode).Reference);
             return handler.UstNode;
         }
+        public override UstNode VisitAttributeArgument(AttributeArgumentSyntax node)
+        {
+            if (!MetaDataSettings.Annotations) return null;
+
+            AttributeArgumentHandler handler = new AttributeArgumentHandler(_context, node);
+            return handler.UstNode;
+        }
         public override UstNode VisitIdentifierName(IdentifierNameSyntax node)
         {
             if (MetaDataSettings.DeclarationNodes)

--- a/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/AttributeArgumentHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/AttributeArgumentHandler.cs
@@ -1,0 +1,21 @@
+using Codelyzer.Analysis.Common;
+using Codelyzer.Analysis.Model;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Codelyzer.Analysis.CSharp.Handlers
+{
+    public class AttributeArgumentHandler : UstNodeHandler
+    {
+        private AttributeArgument Model { get => (AttributeArgument)UstNode; }
+
+        public AttributeArgumentHandler(CodeContext context,
+            AttributeArgumentSyntax syntaxNode)
+            : base(context, syntaxNode, new AttributeArgument())
+        {
+            Model.Identifier = syntaxNode.ToString();
+            Model.ArgumentName = syntaxNode.NameEquals?.Name.ToString();
+            Model.ArgumentExpression = syntaxNode.Expression.ToString();
+        }
+    }
+}

--- a/src/Analysis/Codelyzer.Analysis.Model/AttributeArgument.cs
+++ b/src/Analysis/Codelyzer.Analysis.Model/AttributeArgument.cs
@@ -1,0 +1,18 @@
+using Newtonsoft.Json;
+
+namespace Codelyzer.Analysis.Model
+{
+    public class AttributeArgument : UstNode
+    {
+        [JsonProperty("argument-name", Order = 20)]
+        public string ArgumentName { get; set; }
+
+        [JsonProperty("argument-expression", Order = 25)]
+        public string ArgumentExpression { get; set; }
+
+        public AttributeArgument()
+            : base(IdConstants.AttributeArgumentIdName)
+        {
+        }
+    }
+}

--- a/src/Analysis/Codelyzer.Analysis.Model/Extensions/UstNodeLinq.cs
+++ b/src/Analysis/Codelyzer.Analysis.Model/Extensions/UstNodeLinq.cs
@@ -7,6 +7,11 @@ namespace Codelyzer.Analysis.Model
             return GetNodes<Annotation>(node);
         }
 
+        public static UstList<AttributeArgument> AllAttributeArguments(this UstNode node)
+        {
+            return GetNodes<AttributeArgument>(node);
+        }
+
         public static UstList<BlockStatement> AllBlockStatements(this UstNode node)
         {
             return GetNodes<BlockStatement>(node);

--- a/src/Analysis/Codelyzer.Analysis.Model/IdConstants.cs
+++ b/src/Analysis/Codelyzer.Analysis.Model/IdConstants.cs
@@ -40,6 +40,8 @@ namespace Codelyzer.Analysis.Model
 
         public const string AnnotationIdName = "annotation";
 
+        public const string AttributeArgumentIdName = "attribute-argument";
+
         public const string ConstructorIdName = "constructor";
 
         public const string EnumIdName = "enum";

--- a/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
@@ -268,8 +268,10 @@ namespace Codelyzer.Analysis.Tests
 
             var homeController = result.ProjectResult.SourceFileResults.Where(f => f.FilePath.EndsWith("HomeController.cs")).FirstOrDefault();
             var accountController = result.ProjectResult.SourceFileResults.Where(f => f.FilePath.EndsWith("AccountController.cs")).FirstOrDefault();
+            var storeManagerController = result.ProjectResult.SourceFileResults.Where(f => f.FilePath.EndsWith("StoreManagerController.cs")).FirstOrDefault();
             Assert.NotNull(homeController);
             Assert.NotNull(accountController);
+            Assert.NotNull(storeManagerController);
 
             var classDeclarations = homeController.Children.OfType<Codelyzer.Analysis.Model.NamespaceDeclaration>().FirstOrDefault();
             Assert.Greater(classDeclarations.Children.Count, 0);
@@ -294,6 +296,16 @@ namespace Codelyzer.Analysis.Tests
 
             Assert.AreEqual(2, elementAccess.Count());
             Assert.AreEqual(149, memberAccess.Count());
+
+            var authorizeAttribute = storeManagerController.AllAnnotations().First(a => a.Identifier == "Authorize");
+            var authorizeAttributeArgument = authorizeAttribute.AllAttributeArguments().First();
+            Assert.AreEqual("Roles",authorizeAttributeArgument.ArgumentName);
+            Assert.AreEqual("\"Administrator\"",authorizeAttributeArgument.ArgumentExpression);
+
+            var actionNameAttribute = storeManagerController.AllAnnotations().First(a => a.Identifier == "ActionName");
+            var actionNameAttributeArgument = actionNameAttribute.AllAttributeArguments().First();
+            Assert.IsNull(actionNameAttributeArgument.ArgumentName);
+            Assert.AreEqual("\"Delete\"", actionNameAttributeArgument.ArgumentExpression);
         }
 
         [Test]


### PR DESCRIPTION
## Related issue

Closes: #50


## Description
* Currently, Codelyzer can parse Attribute nodes but not their arguments. 
* Example: `[Authorize(Roles = "Admin")]`
  * `Authorize` can be parsed
  * With this PR, `Roles` and `"Admin"` can be parsed as well

## Supplemental testing
Describe any testing done in addition to existing unit tests

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
