### PR TITLE
Issue 52- Add support for AssignmentExpressionSyntax nodes

### DIFF
--- a/src/Analysis/Codelyzer.Analysis.CSharp/CSharpRoslynProcessor.cs
+++ b/src/Analysis/Codelyzer.Analysis.CSharp/CSharpRoslynProcessor.cs
@@ -167,6 +167,13 @@ namespace Codelyzer.Analysis.CSharp
             HandleReferences(((Annotation)handler.UstNode).Reference);
             return handler.UstNode;
         }
+        public override UstNode VisitAttributeArgument(AttributeArgumentSyntax node)
+        {
+            if (!MetaDataSettings.Annotations) return null;
+
+            AttributeArgumentHandler handler = new AttributeArgumentHandler(_context, node);
+            return handler.UstNode;
+        }
         public override UstNode VisitIdentifierName(IdentifierNameSyntax node)
         {
             if (MetaDataSettings.DeclarationNodes)

--- a/src/Analysis/Codelyzer.Analysis.CSharp/CSharpRoslynProcessor.cs
+++ b/src/Analysis/Codelyzer.Analysis.CSharp/CSharpRoslynProcessor.cs
@@ -139,6 +139,14 @@ namespace Codelyzer.Analysis.CSharp
             LiteralExpressionHandler handler = new LiteralExpressionHandler(_context, node);
             return handler.UstNode;
         }
+
+        public override UstNode VisitAssignmentExpression(AssignmentExpressionSyntax node)
+        {
+            if (!MetaDataSettings.AssignmentExpressions) return null;
+
+            AssignmentExpressionHandler handler = new AssignmentExpressionHandler(_context, node);
+            return handler.UstNode;
+        }
         public override UstNode VisitInvocationExpression(InvocationExpressionSyntax node)
         {
             if (!MetaDataSettings.MethodInvocations) return null;

--- a/src/Analysis/Codelyzer.Analysis.CSharp/CSharpRoslynProcessor.cs
+++ b/src/Analysis/Codelyzer.Analysis.CSharp/CSharpRoslynProcessor.cs
@@ -139,7 +139,6 @@ namespace Codelyzer.Analysis.CSharp
             LiteralExpressionHandler handler = new LiteralExpressionHandler(_context, node);
             return handler.UstNode;
         }
-
         public override UstNode VisitAssignmentExpression(AssignmentExpressionSyntax node)
         {
             if (!MetaDataSettings.AssignmentExpressions) return null;

--- a/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/AssignmentExpressionHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/AssignmentExpressionHandler.cs
@@ -1,0 +1,21 @@
+using Codelyzer.Analysis.Common;
+using Codelyzer.Analysis.Model;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Codelyzer.Analysis.CSharp.Handlers
+{
+    public class AssignmentExpressionHandler : UstNodeHandler
+    {
+        private AssignmentExpression Model { get => (AssignmentExpression)UstNode; }
+
+        public AssignmentExpressionHandler(CodeContext context,
+            AssignmentExpressionSyntax syntaxNode)
+            : base(context, syntaxNode, new AssignmentExpression())
+        {
+            Model.Identifier = syntaxNode.ToString();
+            Model.Left = syntaxNode.Left.ToString();
+            Model.Right = syntaxNode.Right.ToString();
+            Model.Operator = syntaxNode.OperatorToken.ValueText;
+        }
+    }
+}

--- a/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/AttributeArgumentHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/AttributeArgumentHandler.cs
@@ -1,0 +1,21 @@
+using Codelyzer.Analysis.Common;
+using Codelyzer.Analysis.Model;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Codelyzer.Analysis.CSharp.Handlers
+{
+    public class AttributeArgumentHandler : UstNodeHandler
+    {
+        private AttributeArgument Model { get => (AttributeArgument)UstNode; }
+
+        public AttributeArgumentHandler(CodeContext context,
+            AttributeArgumentSyntax syntaxNode)
+            : base(context, syntaxNode, new AttributeArgument())
+        {
+            Model.Identifier = syntaxNode.ToString();
+            Model.ArgumentName = syntaxNode.NameEquals?.Name.ToString();
+            Model.ArgumentExpression = syntaxNode.Expression.ToString();
+        }
+    }
+}

--- a/src/Analysis/Codelyzer.Analysis.Common/AnalyzerConfiguration.cs
+++ b/src/Analysis/Codelyzer.Analysis.Common/AnalyzerConfiguration.cs
@@ -52,5 +52,6 @@ namespace Codelyzer.Analysis
         public bool GenerateBinFiles = false;
         public bool ElementAccess = false;
         public bool MemberAccess = false;
+        public bool AssignmentExpressions = false;
     }
 }

--- a/src/Analysis/Codelyzer.Analysis.Model/AssignmentExpression.cs
+++ b/src/Analysis/Codelyzer.Analysis.Model/AssignmentExpression.cs
@@ -1,0 +1,27 @@
+using Newtonsoft.Json;
+
+namespace Codelyzer.Analysis.Model
+{
+    public class AssignmentExpression : UstNode
+    {
+
+        [JsonProperty("left", Order = 20)]
+        public string Left { get; set; }
+
+        [JsonProperty("right", Order = 25)]
+        public string Right { get; set; }
+
+        [JsonProperty("operator", Order = 30)]
+        public string Operator { get; set; }
+
+        public AssignmentExpression()
+            : base(IdConstants.AssignmentExpressionIdName)
+        {
+        }
+
+        public AssignmentExpression(string idName)
+            : base(idName)
+        {
+        }
+    }
+}

--- a/src/Analysis/Codelyzer.Analysis.Model/AttributeArgument.cs
+++ b/src/Analysis/Codelyzer.Analysis.Model/AttributeArgument.cs
@@ -1,0 +1,18 @@
+using Newtonsoft.Json;
+
+namespace Codelyzer.Analysis.Model
+{
+    public class AttributeArgument : UstNode
+    {
+        [JsonProperty("argument-name", Order = 20)]
+        public string ArgumentName { get; set; }
+
+        [JsonProperty("argument-expression", Order = 25)]
+        public string ArgumentExpression { get; set; }
+
+        public AttributeArgument()
+            : base(IdConstants.AttributeArgumentIdName)
+        {
+        }
+    }
+}

--- a/src/Analysis/Codelyzer.Analysis.Model/Extensions/UstNodeLinq.cs
+++ b/src/Analysis/Codelyzer.Analysis.Model/Extensions/UstNodeLinq.cs
@@ -54,6 +54,11 @@ namespace Codelyzer.Analysis.Model
             return GetNodes<LiteralExpression>(node);
         }
 
+        public static UstList<AssignmentExpression> AllAssignmentExpressions(this UstNode node)
+        {
+            return GetNodes<AssignmentExpression>(node);
+        }
+
         public static UstList<MethodDeclaration> AllMethods(this UstNode node)
         {
             return GetNodes<MethodDeclaration>(node);

--- a/src/Analysis/Codelyzer.Analysis.Model/Extensions/UstNodeLinq.cs
+++ b/src/Analysis/Codelyzer.Analysis.Model/Extensions/UstNodeLinq.cs
@@ -7,6 +7,11 @@ namespace Codelyzer.Analysis.Model
             return GetNodes<Annotation>(node);
         }
 
+        public static UstList<AttributeArgument> AllAttributeArguments(this UstNode node)
+        {
+            return GetNodes<AttributeArgument>(node);
+        }
+
         public static UstList<BlockStatement> AllBlockStatements(this UstNode node)
         {
             return GetNodes<BlockStatement>(node);

--- a/src/Analysis/Codelyzer.Analysis.Model/IdConstants.cs
+++ b/src/Analysis/Codelyzer.Analysis.Model/IdConstants.cs
@@ -31,6 +31,8 @@ namespace Codelyzer.Analysis.Model
         public const string SimpleLambdaExpressionIdName = "simple-lambda-expression";
 
         public const string LiteralIdName = "literal";
+
+        public const string AssignmentExpressionIdName = "assignment-expression";
         
         public const string InvocationIdName = "invocation";
         

--- a/src/Analysis/Codelyzer.Analysis.Model/IdConstants.cs
+++ b/src/Analysis/Codelyzer.Analysis.Model/IdConstants.cs
@@ -40,6 +40,8 @@ namespace Codelyzer.Analysis.Model
 
         public const string AnnotationIdName = "annotation";
 
+        public const string AttributeArgumentIdName = "attribute-argument";
+
         public const string ConstructorIdName = "constructor";
 
         public const string EnumIdName = "enum";

--- a/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
@@ -252,7 +252,8 @@ namespace Codelyzer.Analysis.Tests
                     ReferenceData = true,
                     LoadBuildData = true,
                     ElementAccess = true,
-                    MemberAccess = true
+                    MemberAccess = true,
+                    AssignmentExpressions = true
                 }
             };
             CodeAnalyzer analyzer = CodeAnalyzerFactory.GetAnalyzer(configuration, NullLogger.Instance);
@@ -306,6 +307,13 @@ namespace Codelyzer.Analysis.Tests
             var actionNameAttributeArgument = actionNameAttribute.AllAttributeArguments().First();
             Assert.IsNull(actionNameAttributeArgument.ArgumentName);
             Assert.AreEqual("\"Delete\"", actionNameAttributeArgument.ArgumentExpression);
+            
+            var assignmentExpressions = storeManagerController.AllAssignmentExpressions();
+            var assignmentExpression = assignmentExpressions.First(e => e.Identifier == "ViewBag.GenreId = new SelectList(db.Genres, \"GenreId\", \"Name\")");
+            Assert.AreEqual(9, assignmentExpressions.Count);
+            Assert.AreEqual("ViewBag.GenreId", assignmentExpression.Left);
+            Assert.AreEqual("new SelectList(db.Genres, \"GenreId\", \"Name\")", assignmentExpression.Right);
+            Assert.AreEqual("=", assignmentExpression.Operator);
         }
 
         [Test]

--- a/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
@@ -268,8 +268,10 @@ namespace Codelyzer.Analysis.Tests
 
             var homeController = result.ProjectResult.SourceFileResults.Where(f => f.FilePath.EndsWith("HomeController.cs")).FirstOrDefault();
             var accountController = result.ProjectResult.SourceFileResults.Where(f => f.FilePath.EndsWith("AccountController.cs")).FirstOrDefault();
+            var storeManagerController = result.ProjectResult.SourceFileResults.Where(f => f.FilePath.EndsWith("StoreManagerController.cs")).FirstOrDefault();
             Assert.NotNull(homeController);
             Assert.NotNull(accountController);
+            Assert.NotNull(storeManagerController);
 
             var classDeclarations = homeController.Children.OfType<Codelyzer.Analysis.Model.NamespaceDeclaration>().FirstOrDefault();
             Assert.Greater(classDeclarations.Children.Count, 0);
@@ -294,6 +296,16 @@ namespace Codelyzer.Analysis.Tests
 
             Assert.AreEqual(2, elementAccess.Count());
             Assert.AreEqual(149, memberAccess.Count());
+
+            var authorizeAttribute = storeManagerController.AllAnnotations().First(a => a.Identifier == "Authorize");
+            var authorizeAttributeArgument = authorizeAttribute.AllAttributeArguments().First();
+            Assert.AreEqual("Roles",authorizeAttributeArgument.ArgumentName);
+            Assert.AreEqual("\"Administrator\"",authorizeAttributeArgument.ArgumentExpression);
+
+            var actionNameAttribute = storeManagerController.AllAnnotations().First(a => a.Identifier == "ActionName");
+            var actionNameAttributeArgument = actionNameAttribute.AllAttributeArguments().First();
+            Assert.IsNull(actionNameAttributeArgument.ArgumentName);
+            Assert.AreEqual("\"Delete\"", actionNameAttributeArgument.ArgumentExpression);
         }
 
         [Test]


### PR DESCRIPTION
## Related issue

Closes: #52 


## Description
* Now handles expressions such as `myClass.Property = someValue`
* Note: this branch was accidentally created from PR #51 (PR #51 should be reviewed first)

## Supplemental testing
Describe any testing done in addition to existing unit tests

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
