### PR TITLE
Issue 53- Populate the parent property of UstNode objects

### DIFF
--- a/src/Analysis/Codelyzer.Analysis.CSharp/CSharpRoslynProcessor.cs
+++ b/src/Analysis/Codelyzer.Analysis.CSharp/CSharpRoslynProcessor.cs
@@ -60,7 +60,8 @@ namespace Codelyzer.Analysis.CSharp
             RootNode.Language = node.Language;
 
             RootNode.Children.AddRange(children);
-            
+            AssignParentNode(RootNode.Children, RootNode);
+
             return RootNode;
         }
 
@@ -292,6 +293,7 @@ namespace Codelyzer.Analysis.CSharp
                 if (ustNode != null)
                 {
                     AddChildNodes(ustNode.Children, node);
+                    AssignParentNode(ustNode.Children, ustNode);
                 }
                 return ustNode;
             }
@@ -307,6 +309,13 @@ namespace Codelyzer.Analysis.CSharp
             if (children != null && nodeChildren != null)
             {
                 nodeChildren.AddRange(children);
+            }
+        }
+        private void AssignParentNode(List<UstNode> children, UstNode parentNode)
+        {
+            foreach (var child in children)
+            {
+                child.Parent = parentNode;
             }
         }
         public void Dispose()

--- a/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
@@ -294,6 +294,11 @@ namespace Codelyzer.Analysis.Tests
 
             Assert.AreEqual(2, elementAccess.Count());
             Assert.AreEqual(149, memberAccess.Count());
+
+            foreach (var child in accountController.Children)
+            {
+                Assert.AreEqual(accountController, child.Parent);
+            }
         }
 
         [Test]


### PR DESCRIPTION
## Related issue

Closes: #53


## Description
* Parent is a property that exists on the UstNode class but it is unused
* Populating the Parent property will improve analysis capabilities by preserving the two-way structure of the original syntax tree

## Supplemental testing
Describe any testing done in addition to existing unit tests

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
