### PR TITLE
fix AllInvocationExpressions() method

### DIFF
--- a/src/Analysis/Codelyzer.Analysis.Model/Extensions/UstNodeLinq.cs
+++ b/src/Analysis/Codelyzer.Analysis.Model/Extensions/UstNodeLinq.cs
@@ -29,14 +29,7 @@ namespace Codelyzer.Analysis.Model
 
         public static UstList<InvocationExpression> AllInvocationExpressions(this UstNode node)
         {
-            // Combine method invocations and object creations
-            var objCreations = GetNodes<ObjectCreationExpression>(node)
-                .ConvertAll(x => (InvocationExpression)x);
-            
-            var result = GetNodes<InvocationExpression>(node);
-            result.AddRange(objCreations);
-            
-            return result;
+            return  GetNodes<InvocationExpression>(node);
         }
         
         public static UstList<ObjectCreationExpression> AllObjectCreationExpressions(this UstNode node)

--- a/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
@@ -205,6 +205,9 @@ namespace Codelyzer.Analysis.Tests
             var houseControllerClass = classDeclarations.First(c => c.Identifier == "HouseController");
             Assert.AreEqual("public", houseControllerClass.Modifiers);
 
+            var houseMapper = result.ProjectResult.SourceFileResults.First(f => f.FilePath.EndsWith("HouseMapper.cs"));
+            Assert.AreEqual(2, houseMapper.AllInvocationExpressions().Count);
+
             var dllFiles = Directory.EnumerateFiles(Path.Combine(result.ProjectResult.ProjectRootPath, "bin"), "*.dll");
             Assert.AreEqual(dllFiles.Count(), 16);
 


### PR DESCRIPTION
## Related issue

Closes: #56


## Description
* Fix AllInvocationExpressions() method to not report duplicates
* Originally, `ObjectCreationExpression` nodes were explicitly appended to the results of `GetNodes<InvocationExpression>()`, but `ObjectCreationExpression` nodes were already included in those results as `ObjectCreationExpression` is a child class of `InvocationExpression`

## Supplemental testing
Describe any testing done in addition to existing unit tests

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
