### PR TITLE
Picks up identifiers when part of a typed argument list

### DIFF
--- a/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/IdentifierNameHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/IdentifierNameHandler.cs
@@ -14,6 +14,7 @@ namespace Codelyzer.Analysis.CSharp.Handlers
             typeof(ConstructorDeclarationSyntax),
             typeof(ClassDeclarationSyntax),
             typeof(VariableDeclarationSyntax),
+            typeof(TypeParameterListSyntax),
             typeof(ParameterSyntax),
             typeof(ObjectCreationExpressionSyntax)};
 


### PR DESCRIPTION
## Related issue

Closes: #58 


## Description
Adds TypedArgumentSyntaxList to list of parents for identifier

## Supplemental testing
Testing locally using a project with a method with a return type Task<IHttpActionResult>