### PR TITLE
Fix file reference parsing

### DIFF
--- a/src/Analysis/Codelyzer.Analysis.Build/ProjectBuildHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.Build/ProjectBuildHandler.cs
@@ -56,24 +56,23 @@ namespace Codelyzer.Analysis.Build
                 && d.FirstAttribute?.Name == "Label" && d.FirstAttribute?.Value == "PortingInfo");
 
                 var fileReferences = portingNode?.FirstNode?.ToString()
-                    .Split(new string[] { Environment.NewLine, "\t", "\\t" }, StringSplitOptions.RemoveEmptyEntries)?
-                    .Where(s => !(s.Contains("<!-") || s.Contains("-->"))).Select(s=>s?.Trim()).ToList();
+                    .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)?
+                    .Where(s => !(s.Contains("<!-") || s.Contains("-->")))
+                    .Select(s=>s.Trim())
+                    .ToList();
 
-                if (fileReferences != null)
+                fileReferences?.ForEach(fileRef =>
                 {
-                    fileReferences.ForEach(fileRef =>
+                    try
                     {
-                        try
-                        {
-                            references.Add(MetadataReference.CreateFromFile(fileRef));
-                        }
-                        catch (Exception ex)
-                        {
-                            Logger.LogError(ex, "Error while parsing metadata file");
-                        }
+                        references.Add(MetadataReference.CreateFromFile(fileRef));
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.LogError(ex, "Error while parsing metadata file");
+                    }
 
-                    });
-                }
+                });
             }
 
             return references;

--- a/src/Analysis/Codelyzer.Analysis.Build/ProjectBuildHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.Build/ProjectBuildHandler.cs
@@ -50,32 +50,43 @@ namespace Codelyzer.Analysis.Build
                 Logger.LogError(ex, "Error loading project file");
             }   
 
-            if (projectFile != null)
+            var fileReferences = ExtractFileReferencesFromProject(projectFile);
+            fileReferences?.ForEach(fileRef =>
             {
-                var portingNode = projectFile.Descendants().FirstOrDefault(d => d.Name.LocalName == "ItemGroup"
-                && d.FirstAttribute?.Name == "Label" && d.FirstAttribute?.Value == "PortingInfo");
-
-                var fileReferences = portingNode?.FirstNode?.ToString()
-                    .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)?
-                    .Where(s => !(s.Contains("<!-") || s.Contains("-->")))
-                    .Select(s=>s.Trim())
-                    .ToList();
-
-                fileReferences?.ForEach(fileRef =>
+                try
                 {
-                    try
-                    {
-                        references.Add(MetadataReference.CreateFromFile(fileRef));
-                    }
-                    catch (Exception ex)
-                    {
-                        Logger.LogError(ex, "Error while parsing metadata file");
-                    }
+                    references.Add(MetadataReference.CreateFromFile(fileRef));
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError(ex, "Error while parsing metadata file");
+                }
 
-                });
-            }
+            });
 
             return references;
+        }
+
+        private List<string> ExtractFileReferencesFromProject(XDocument projectFileContents)
+        {
+            if (projectFileContents == null)
+            {
+                return null;
+            }
+
+            var portingNode = projectFileContents.Descendants()
+                .FirstOrDefault(d => 
+                    d.Name.LocalName == "ItemGroup"
+                    && d.FirstAttribute?.Name == "Label" 
+                    && d.FirstAttribute?.Value == "PortingInfo");
+
+            var fileReferences = portingNode?.FirstNode?.ToString()
+                .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)?
+                .Where(s => !(s.Contains("<!-") || s.Contains("-->")))
+                .Select(s => s.Trim())
+                .ToList();
+
+            return fileReferences;
         }
 
         private async Task<Compilation> SetPrePortCompilation()

--- a/tst/Codelyzer.Analysis.Tests/ProjectBuildHandlerTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/ProjectBuildHandlerTests.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Xml.Linq;
+using Codelyzer.Analysis.Build;
+using NUnit.Framework;
+
+namespace Codelyzer.Analysis.Tests
+{
+    public class ProjectBuildHandlerTests
+    {
+        [Test]
+        public void ExtractFileReferencesFromProject_Retrieves_Expected_ReferencePaths()
+        {
+            var projectFileContent = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <FrameworkReference Include=""Microsoft.AspNetCore.App"" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include=""MyFirstPackage"" Version=""1.0.0"" />
+    <PackageReference Include=""MySecondPackage"" Version=""2.0.0"" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include=""TheMainProject"" />
+    <ProjectReference Include=""TheDependency"" />
+  </ItemGroup>
+  <ItemGroup Label=""PortingInfo"">
+  <!-- DO NOT REMOVE WHILE PORTING
+    C:\\RandomFile.dll
+    C:\\this\\is\\some\\path\\to\\Some.dll
+  -->
+  </ItemGroup>
+</Project>";
+            using var stringReader = new StringReader(projectFileContent);
+            var projectFileDoc = XDocument.Load(stringReader);
+            var projectBuildHandlerInstance = new ProjectBuildHandler(null);
+            var extractFileReferencesFromProjectMethod =
+                TestUtils.GetPrivateMethod(projectBuildHandlerInstance.GetType(), "ExtractFileReferencesFromProject");
+
+            // Invoke method and read contents of method output
+            var fileReferences = (List<string>)extractFileReferencesFromProjectMethod.Invoke(projectBuildHandlerInstance, new object[] { projectFileDoc });
+            var expectedFileReferences = new List<string>
+            {
+                @"C:\\RandomFile.dll",
+                @"C:\\this\\is\\some\\path\\to\\Some.dll"
+            };
+
+            CollectionAssert.AreEquivalent(expectedFileReferences, fileReferences);
+        }
+    }
+}

--- a/tst/Codelyzer.Analysis.Tests/TestUtils.cs
+++ b/tst/Codelyzer.Analysis.Tests/TestUtils.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Reflection;
+using NUnit.Framework;
+
+namespace Codelyzer.Analysis.Tests
+{
+    public class TestUtils
+    {
+        public static MethodInfo GetPrivateMethod(Type type, string methodName)
+        {
+            if (string.IsNullOrWhiteSpace(methodName))
+                Assert.Fail("methodName cannot be null or whitespace");
+
+            var method = type.GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance);
+
+            if (method == null)
+                Assert.Fail("{0} method not found", methodName);
+
+            return method;
+        }
+    }
+}


### PR DESCRIPTION
## Related issue

Closes: #73


## Description
* Parsing file references no longer splits on `\t` characters. Instead, this is handled by a `.Trim()` call so leading and trailing white space is removed. This prevents the parser from thinking whitespace exists in the middle of a string.
* The parsing function was moved to its own method to make it easier to test

## Supplemental testing
Describe any testing done in addition to existing unit tests

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
