### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,56 @@
+version: 2
+registries:
+  porting-assistant-nuget:
+    type: nuget-feed
+    url: https://s3-us-west-2.amazonaws.com/aws.portingassistant.dotnet.download/nuget/index.json
+  nuget-org:
+    type: nuget-feed
+    url: https://api.nuget.org/v3/index.json
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/src/Analysis/Codelyzer.Analysis"
+    registries:
+      - porting-assistant-nuget
+      - nuget-org
+    schedule:
+      interval: "daily"
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/src/Analysis/Codelyzer.Analysis.Build"
+    registries:
+      - porting-assistant-nuget
+      - nuget-org
+    schedule:
+      interval: "daily"
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/src/Analysis/Codelyzer.Analysis.Common"
+    registries:
+      - porting-assistant-nuget
+      - nuget-org
+    schedule:
+      interval: "daily"
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/src/Analysis/Codelyzer.Analysis.CSharp"
+    registries:
+      - porting-assistant-nuget
+      - nuget-org
+    schedule:
+      interval: "daily"
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/src/Analysis/Codelyzer.Analysis.Model"
+    registries:
+      - porting-assistant-nuget
+      - nuget-org
+    schedule:
+      interval: "daily"
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/tst/Codelyzer.Analysis.Tests"
+    registries:
+      - porting-assistant-nuget
+      - nuget-org
+    schedule:
+      interval: "daily"

--- a/src/Analysis/Codelyzer.Analysis.Build/Codelyzer.Analysis.Build.csproj
+++ b/src/Analysis/Codelyzer.Analysis.Build/Codelyzer.Analysis.Build.csproj
@@ -10,7 +10,7 @@
       <PackageReference Include="Buildalyzer" Version="3.2.0" />
       <PackageReference Include="Buildalyzer.Logger" Version="3.2.0" />
       <PackageReference Include="Buildalyzer.Workspaces" Version="3.2.0" />
-      <PackageReference Include="NuGet.Packaging" Version="5.9.1" />
+      <PackageReference Include="NuGet.Packaging" Version="5.10.0" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     </ItemGroup>
 
@@ -19,7 +19,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.194" />
+      <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.231" />
     </ItemGroup>
 
 </Project>

--- a/src/Analysis/Codelyzer.Analysis.Build/Codelyzer.Analysis.Build.csproj
+++ b/src/Analysis/Codelyzer.Analysis.Build/Codelyzer.Analysis.Build.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Buildalyzer" Version="3.2.0" />
-      <PackageReference Include="Buildalyzer.Logger" Version="3.2.0" />
-      <PackageReference Include="Buildalyzer.Workspaces" Version="3.2.0" />
+      <PackageReference Include="Buildalyzer" Version="3.2.2" />
+      <PackageReference Include="Buildalyzer.Logger" Version="3.2.2" />
+      <PackageReference Include="Buildalyzer.Workspaces" Version="3.2.2" />
       <PackageReference Include="NuGet.Packaging" Version="5.10.0" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     </ItemGroup>

--- a/src/Analysis/Codelyzer.Analysis.CSharp/Codelyzer.Analysis.CSharp.csproj
+++ b/src/Analysis/Codelyzer.Analysis.CSharp/Codelyzer.Analysis.CSharp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -12,7 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.194" />
+      <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.231" />
     </ItemGroup>
 
 </Project>

--- a/src/Analysis/Codelyzer.Analysis.Common/Codelyzer.Analysis.Common.csproj
+++ b/src/Analysis/Codelyzer.Analysis.Common/Codelyzer.Analysis.Common.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -15,7 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.194" />
+      <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.231" />
     </ItemGroup>
 
 </Project>

--- a/src/Analysis/Codelyzer.Analysis.Model/Codelyzer.Analysis.Model.csproj
+++ b/src/Analysis/Codelyzer.Analysis.Model/Codelyzer.Analysis.Model.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.194" />
+      <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.231" />
     </ItemGroup>
 
 </Project>

--- a/src/Analysis/Codelyzer.Analysis.Model/Codelyzer.Analysis.Model.csproj
+++ b/src/Analysis/Codelyzer.Analysis.Model/Codelyzer.Analysis.Model.csproj
@@ -7,7 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis" Version="3.11.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     </ItemGroup>

--- a/src/Analysis/Codelyzer.Analysis/Codelyzer.Analysis.csproj
+++ b/src/Analysis/Codelyzer.Analysis/Codelyzer.Analysis.csproj
@@ -18,7 +18,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.194" />
+      <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.231" />
     </ItemGroup>
 
 </Project>

--- a/tst/Codelyzer.Analysis.Tests/Codelyzer.Analysis.Tests.csproj
+++ b/tst/Codelyzer.Analysis.Tests/Codelyzer.Analysis.Tests.csproj
@@ -8,13 +8,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.msbuild" Version="3.0.3">
+        <PackageReference Include="coverlet.msbuild" Version="3.1.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="nunit" Version="3.13.1" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+        <PackageReference Include="nunit" Version="3.13.2" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Related issue

Closes: #83


## Description
* Configures Dependabot to submit a PR to update any Nuget or Porting Assistant dependencies that are not referencing the latest version (1 PR per project dependency)
* This check is performed daily
* **Caveats**
  * This yaml file will need to be updated if any new projects are added to the solution or a package from a new nuget feed is referenced
  * Dependabot only looks for official releases (pre-releases are not considered)

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
