### PR TITLE
Check file existence before MetadataReference Creation.

### DIFF
--- a/src/Analysis/Codelyzer.Analysis.Build/Models/ProjectBuildResult.cs
+++ b/src/Analysis/Codelyzer.Analysis.Build/Models/ProjectBuildResult.cs
@@ -3,7 +3,6 @@ using Microsoft.CodeAnalysis;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
 
 namespace Codelyzer.Analysis.Build
 {
@@ -22,6 +21,7 @@ namespace Codelyzer.Analysis.Build
         public string TargetFramework { get; set; }
         public List<string> TargetFrameworks { get; set; }
         public List<string> PreportReferences { get; set; }
+        public List<string> MissingReferences { get; set; }
         public string ProjectGuid { get; set; }        
         public string ProjectType { get; set; }
         public bool IsSyntaxAnalysis { get; set; }
@@ -32,6 +32,7 @@ namespace Codelyzer.Analysis.Build
             SourceFiles = new List<string>();
             TargetFrameworks = new List<string>();
             PreportReferences = new List<string>();
+            MissingReferences = new List<string>();
         }
 
         public bool IsBuildSuccess()

--- a/src/Analysis/Codelyzer.Analysis.Build/ProjectBuildHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.Build/ProjectBuildHandler.cs
@@ -25,6 +25,7 @@ namespace Codelyzer.Analysis.Build
         private Compilation Compilation;
         private Compilation PrePortCompilation;
         private List<string> PrePortMetaReferences;
+        private List<string> MissingMetaReferences { get; set; }
 
         private List<string> Errors { get; set; }
         private ILogger Logger;
@@ -66,6 +67,7 @@ namespace Codelyzer.Analysis.Build
             fileReferences?.ForEach(fileRef =>
             {
                 if(!File.Exists(fileRef)) {
+                    MissingMetaReferences.Add(fileRef);
                     Logger.LogWarning("Assembly {} referenced does not exist.", fileRef);
                     return;
                 }
@@ -275,6 +277,7 @@ namespace Codelyzer.Analysis.Build
             _metaReferences = metaReferences;
 
             Errors = new List<string>();
+            MissingMetaReferences = new List<string>();
         }
         public ProjectBuildHandler(ILogger logger, Project project, AnalyzerConfiguration analyzerConfiguration = null)
         {
@@ -296,6 +299,7 @@ namespace Codelyzer.Analysis.Build
             this.Project = project.WithCompilationOptions(options);
             _projectPath = project.FilePath;
             Errors = new List<string>();
+            MissingMetaReferences = new List<string>();
         }
         public ProjectBuildHandler(ILogger logger, Project project, Compilation compilation, Compilation preportCompilation, AnalyzerConfiguration analyzerConfiguration = null)
         {
@@ -306,6 +310,7 @@ namespace Codelyzer.Analysis.Build
             this.Compilation = compilation;
             this.PrePortCompilation = preportCompilation;
             Errors = new List<string>();
+            MissingMetaReferences = new List<string>();
         }
 
         public ProjectBuildHandler(ILogger logger, string projectPath, List<string> oldReferences, List<string> references, AnalyzerConfiguration analyzerConfiguration = null)
@@ -319,6 +324,7 @@ namespace Codelyzer.Analysis.Build
             this.PrePortCompilation = oldReferences?.Any() == true ? CreateManualCompilation(projectPath, oldReferences) : null;
 
             Errors = new List<string>();
+            MissingMetaReferences = new List<string>();
 
             var errors = Compilation.GetDiagnostics()
                .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error && diagnostic.GetMessage()?.Equals(KnownErrors.NoMainMethodMessage) != true);
@@ -351,7 +357,8 @@ namespace Codelyzer.Analysis.Build
                 Compilation = Compilation,
                 PrePortCompilation = PrePortCompilation,
                 IsSyntaxAnalysis = isSyntaxAnalysis,
-                PreportReferences = PrePortMetaReferences
+                PreportReferences = PrePortMetaReferences,
+                MissingReferences = MissingMetaReferences
             };
 
             GetTargetFrameworks(projectBuildResult, AnalyzerResult);
@@ -393,7 +400,8 @@ namespace Codelyzer.Analysis.Build
                 Compilation = Compilation,
                 PrePortCompilation = PrePortCompilation,
                 IsSyntaxAnalysis = isSyntaxAnalysis,
-                PreportReferences = PrePortMetaReferences
+                PreportReferences = PrePortMetaReferences,
+                MissingReferences = MissingMetaReferences
             };
 
             GetTargetFrameworks(projectBuildResult, AnalyzerResult);

--- a/tst/Codelyzer.Analysis.Tests/Codelyzer.Analysis.Tests.csproj
+++ b/tst/Codelyzer.Analysis.Tests/Codelyzer.Analysis.Tests.csproj
@@ -15,6 +15,7 @@
         <PackageReference Include="nunit" Version="3.13.2" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+        <PackageReference Include="Moq" Version="4.16.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tst/Codelyzer.Analysis.Tests/ProjectBuildHandlerTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/ProjectBuildHandlerTests.cs
@@ -150,8 +150,13 @@ namespace Codelyzer.Analysis.Tests
             // Invoke method and read contents of method output
             var metadataReferences = (List<PortableExecutableReference>)loadMetadataReferencesMethod.Invoke(projectBuildHandlerInstance, new object[] { projectFileDoc });
             var expectedMetadataReferences = new List<PortableExecutableReference>();
-
             CollectionAssert.AreEquivalent(expectedMetadataReferences, metadataReferences);
+
+            // Validate MissingMetaReferences
+            var prop = TestUtils.GetPrivateProperty(projectBuildHandlerInstance.GetType(), "MissingMetaReferences");
+            List<string> missingMetaReferences = (List<string>)prop.GetValue(projectBuildHandlerInstance);
+            List<string> expectedMissingMetaReferences = new List<string> { @"C:\\RandomFile.dll", @"C:\\this\\is\\some\\path\\to\\Some.dll" };
+            CollectionAssert.AreEquivalent(expectedMissingMetaReferences, missingMetaReferences);
         }
 
         [Test]
@@ -193,6 +198,12 @@ namespace Codelyzer.Analysis.Tests
             // Invoke method and read contents of method output
             var metadataReferences = (List<PortableExecutableReference>)loadMetadataReferencesMethod.Invoke(projectBuildHandlerInstance, new object[] { projectFileDoc });
             Assert.AreEqual(1, metadataReferences.Count);
+
+            // Validate MissingMetaReferences
+            var prop = TestUtils.GetPrivateProperty(projectBuildHandlerInstance.GetType(), "MissingMetaReferences");
+            List<string> missingMetaReferences = (List<string>)prop.GetValue(projectBuildHandlerInstance);
+            List<string> expectedMissingMetaReferences = new List<string> { @"C:\\RandomFile.dll" };
+            CollectionAssert.AreEquivalent(expectedMissingMetaReferences, missingMetaReferences);
         }
     }
 }

--- a/tst/Codelyzer.Analysis.Tests/ProjectBuildHandlerTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/ProjectBuildHandlerTests.cs
@@ -3,16 +3,21 @@ using System.IO;
 using System.Xml.Linq;
 using Codelyzer.Analysis.Build;
 using NUnit.Framework;
+using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.Logging;
+using Moq;
 
 namespace Codelyzer.Analysis.Tests
 {
     public class ProjectBuildHandlerTests
     {
-        [Test]
-        public void ExtractFileReferencesFromProject_Retrieves_Expected_ReferencePaths()
+        protected string projectFileContent;
+        protected string tmpTestFixturePath;
+
+        [OneTimeSetUp]
+        public virtual void OneTimeSetUp()
         {
-            var projectFileContent = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
+            projectFileContent = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
@@ -28,12 +33,28 @@ namespace Codelyzer.Analysis.Tests
     <ProjectReference Include=""TheDependency"" />
   </ItemGroup>
   <ItemGroup Label=""PortingInfo"">
-  <!-- DO NOT REMOVE WHILE PORTING
-    C:\\RandomFile.dll
-    C:\\this\\is\\some\\path\\to\\Some.dll
-  -->
+    <!-- DO NOT REMOVE WHILE PORTING
+        C:\\RandomFile.dll
+        C:\\this\\is\\some\\path\\to\\Some.dll
+    -->
   </ItemGroup>
 </Project>";
+            tmpTestFixturePath = Path.GetFullPath(Path.Combine(
+                Path.GetTempPath(),
+                Path.GetRandomFileName()));
+            Directory.CreateDirectory(tmpTestFixturePath);
+        }
+
+        [OneTimeTearDown]
+        public void Cleanup()
+        {
+            Directory.Delete(tmpTestFixturePath, true);
+        }
+
+
+        [Test]
+        public void ExtractFileReferencesFromProject_Retrieves_Expected_ReferencePaths()
+        {
             using var stringReader = new StringReader(projectFileContent);
             var projectFileDoc = XDocument.Load(stringReader);
             var projectBuildHandlerInstance = new ProjectBuildHandler(null);
@@ -49,6 +70,129 @@ namespace Codelyzer.Analysis.Tests
             };
 
             CollectionAssert.AreEquivalent(expectedFileReferences, fileReferences);
+        }
+
+        [Test]
+        public void LoadProjectFile_Returns_Expected_XDocument()
+        {
+            var testProjectFilePath = Path.GetFullPath(Path.Combine(
+                tmpTestFixturePath,
+                "ProjectFileWithNonExistingMetaReferences.xml"
+                ));
+            File.WriteAllText(testProjectFilePath, projectFileContent);
+            var projectBuildHandlerInstance = new ProjectBuildHandler(null);
+            var loadProjectFileMethod =
+                TestUtils.GetPrivateMethod(projectBuildHandlerInstance.GetType(), "LoadProjectFile");
+
+            // Invoke method and read contents of method output
+            var projectFile = (XDocument)loadProjectFileMethod.Invoke(projectBuildHandlerInstance, new object[] { testProjectFilePath });
+
+            Assert.AreEqual(projectFileContent, projectFile.ToString());
+        }
+
+
+        [Test]
+        public void LoadProjectFile_Returns_Null_On_Invalid_ProjectFilePath()
+        {
+            var projectBuildHandlerInstance = new ProjectBuildHandler(null);
+            var loadProjectFileMethod =
+                TestUtils.GetPrivateMethod(projectBuildHandlerInstance.GetType(), "LoadProjectFile");
+
+            // Invoke method and read contents of method output
+            var projectFile = (XDocument)loadProjectFileMethod.Invoke(projectBuildHandlerInstance, new object[] { @"C:\\Invalid\\ProjectFilePath.csproj" });
+            
+            Assert.AreEqual(null, projectFile);
+        }
+        [Test]
+        public void LoadProjectFile_Returns_Null_On_Invalid_ProjectFileContent()
+        {
+            var testProjectFilePath = Path.GetFullPath(Path.Combine(
+                tmpTestFixturePath,
+                "InvalidProjectFile.xml"
+                ));
+            File.WriteAllText(testProjectFilePath, "Invalid Project File Content!!!");
+
+            var mockedLogger = new Mock<ILogger>();
+            var projectBuildHandlerInstance = new ProjectBuildHandler(mockedLogger.Object, null, new List<string>());
+            var loadProjectFileMethod =
+                TestUtils.GetPrivateMethod(projectBuildHandlerInstance.GetType(), "LoadProjectFile");
+
+            // Invoke method and read contents of method output
+            var projectFile = (XDocument)loadProjectFileMethod.Invoke(projectBuildHandlerInstance, new object[] { testProjectFilePath });
+
+            Assert.AreEqual(null, projectFile);
+        }
+
+        [Test]
+        public void LoadMetadataReferences_Returns_Empty_On_Invalid_ProjectFile()
+        {
+            var projectBuildHandlerInstance = new ProjectBuildHandler(null);
+            var loadMetadataReferencesMethod =
+                TestUtils.GetPrivateMethod(projectBuildHandlerInstance.GetType(), "LoadMetadataReferences");
+
+            // Invoke method and read contents of method output
+            var metadataReferences = (List<PortableExecutableReference>)loadMetadataReferencesMethod.Invoke(projectBuildHandlerInstance, new object[] { null });
+            var expectedMetadataReferences = new List<PortableExecutableReference>();
+
+            CollectionAssert.AreEquivalent(expectedMetadataReferences, metadataReferences);
+        }
+
+        [Test]
+        public void LoadMetadataReferences_Returns_Empty_On_Invalid_ReferencePath()
+        {
+            var projectFileDoc = XDocument.Load(new StringReader(projectFileContent));
+
+            var mockedLogger = new Mock<ILogger>();
+            var projectBuildHandlerInstance = new ProjectBuildHandler(mockedLogger.Object, null, new List<string>());
+            var loadMetadataReferencesMethod =
+                TestUtils.GetPrivateMethod(projectBuildHandlerInstance.GetType(), "LoadMetadataReferences");
+
+            // Invoke method and read contents of method output
+            var metadataReferences = (List<PortableExecutableReference>)loadMetadataReferencesMethod.Invoke(projectBuildHandlerInstance, new object[] { projectFileDoc });
+            var expectedMetadataReferences = new List<PortableExecutableReference>();
+
+            CollectionAssert.AreEquivalent(expectedMetadataReferences, metadataReferences);
+        }
+
+        [Test]
+        public void LoadMetadataReferences_Returns_Expected_ReferencePath()
+        {
+            var testReferencePath = Path.Combine(
+                TestContext.CurrentContext.TestDirectory,
+                "Codelyzer.Analysis.Tests.dll"
+                );
+            var projectFileContent = string.Format(@"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <FrameworkReference Include=""Microsoft.AspNetCore.App"" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include=""MyFirstPackage"" Version=""1.0.0"" />
+    <PackageReference Include=""MySecondPackage"" Version=""2.0.0"" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include=""TheMainProject"" />
+    <ProjectReference Include=""TheDependency"" />
+  </ItemGroup>
+  <ItemGroup Label=""PortingInfo"">
+    <!-- DO NOT REMOVE WHILE PORTING
+        C:\\RandomFile.dll
+        {0}
+    -->
+  </ItemGroup>
+</Project>", testReferencePath);
+            var projectFileDoc = XDocument.Load(new StringReader(projectFileContent));
+
+            var mockedLogger = new Mock<ILogger>();
+            var projectBuildHandlerInstance = new ProjectBuildHandler(mockedLogger.Object, null, new List<string>());
+            var loadMetadataReferencesMethod =
+                TestUtils.GetPrivateMethod(projectBuildHandlerInstance.GetType(), "LoadMetadataReferences");
+
+            // Invoke method and read contents of method output
+            var metadataReferences = (List<PortableExecutableReference>)loadMetadataReferencesMethod.Invoke(projectBuildHandlerInstance, new object[] { projectFileDoc });
+            Assert.AreEqual(1, metadataReferences.Count);
         }
     }
 }

--- a/tst/Codelyzer.Analysis.Tests/TestUtils.cs
+++ b/tst/Codelyzer.Analysis.Tests/TestUtils.cs
@@ -18,5 +18,18 @@ namespace Codelyzer.Analysis.Tests
 
             return method;
         }
+
+        public static PropertyInfo GetPrivateProperty(Type type, string propertyName)
+        {
+            if (string.IsNullOrWhiteSpace(propertyName))
+                Assert.Fail("propertyName cannot be null or whitespace");
+
+            PropertyInfo property = type.GetProperty(propertyName, BindingFlags.NonPublic | BindingFlags.Instance);
+
+            if (property == null)
+                Assert.Fail("{0} property not found", propertyName);
+
+            return property;
+        }
     }
 }


### PR DESCRIPTION
## Related issue

Closes: #85


## Description
`LoadMetadataReferences` loads project file, extract the file paths referenced in the project file and parse the `MetadataReference`s from the file paths. We've observed `FileNotFoundException` being thrown during `MetadataReference` creation. This patch addresses this issue by checking file existence.

Also refactored some code so that they are unit test friendly.

## Supplemental testing
Added 5 unit tests including positive and negative tests.

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
