### PR TITLE
added identifier name type for qualified name syntax

### DIFF
--- a/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/IdentifierNameHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/IdentifierNameHandler.cs
@@ -18,7 +18,9 @@ namespace Codelyzer.Analysis.CSharp.Handlers
             typeof(TypeParameterListSyntax),
             typeof(ParameterSyntax),
             typeof(TypeArgumentListSyntax),
-            typeof(ObjectCreationExpressionSyntax)};
+            typeof(ObjectCreationExpressionSyntax),
+            typeof(QualifiedNameSyntax),
+        };
 
         private DeclarationNode Model { get => (DeclarationNode)UstNode; }
 

--- a/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
@@ -356,7 +356,7 @@ namespace Codelyzer.Analysis.Tests
             var accountClassDeclaration = accountController.Children.OfType<NamespaceDeclaration>().FirstOrDefault();
             Assert.NotNull(accountClassDeclaration);
 
-            var classDeclaration = homeController.Children.OfType<Codelyzer.Analysis.Model.NamespaceDeclaration>().FirstOrDefault().Children[0];
+            var classDeclaration = homeController.Children.OfType<Codelyzer.Analysis.Model.NamespaceDeclaration>().FirstOrDefault().Children.OfType<Codelyzer.Analysis.Model.ClassDeclaration>().FirstOrDefault();
             Assert.NotNull(classDeclaration);
 
             var declarationNodes = classDeclaration.AllDeclarationNodes();

--- a/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
@@ -464,8 +464,8 @@ namespace Codelyzer.Analysis.Tests
             var accountClassDeclarationOld = accountControllerOld.Children.OfType<NamespaceDeclaration>().FirstOrDefault();
             Assert.NotNull(accountClassDeclaration);
 
-            var classDeclaration = homeController.Children.OfType<Codelyzer.Analysis.Model.NamespaceDeclaration>().FirstOrDefault().Children[0];
-            var classDeclarationOld = homeControllerOld.Children.OfType<Codelyzer.Analysis.Model.NamespaceDeclaration>().FirstOrDefault().Children[0];
+            var classDeclaration = homeController.Children.OfType<Codelyzer.Analysis.Model.NamespaceDeclaration>().FirstOrDefault().Children.OfType<Codelyzer.Analysis.Model.ClassDeclaration>().FirstOrDefault();
+            var classDeclarationOld = homeControllerOld.Children.OfType<Codelyzer.Analysis.Model.NamespaceDeclaration>().FirstOrDefault().Children.OfType<Codelyzer.Analysis.Model.ClassDeclaration>().FirstOrDefault();
             Assert.NotNull(classDeclaration);
 
             var declarationNodes = classDeclaration.AllDeclarationNodes();
@@ -680,7 +680,7 @@ namespace Mvc3ToolsUpdateWeb_Default.Controllers
             Assert.NotNull(updatedSourceFile);
             Assert.AreEqual(3, updatedSourceFile.AllMethods().Count);
             Assert.AreEqual(5, updatedSourceFile.AllLiterals().Count);
-            Assert.AreEqual(5, updatedSourceFile.AllDeclarationNodes().Count);
+            Assert.AreEqual(24, updatedSourceFile.AllDeclarationNodes().Count);
         }
 
         [Test]


### PR DESCRIPTION
## Related issue

Closes: #112 


## Description
Currently if we use a namespace prefix for any object declaration node, the normally included child node for the identifier name is not present.

All object declaration nodes should contains an identifier name syntax node as child. (a declaration-node type).

## Supplemental testing
Describe any testing done in addition to existing unit tests

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
