### PR TITLE
update msbuild location logic

### DIFF
--- a/src/Analysis/Codelyzer.Analysis.Build/WorkspaceBuilderHelper.cs
+++ b/src/Analysis/Codelyzer.Analysis.Build/WorkspaceBuilderHelper.cs
@@ -569,13 +569,16 @@ namespace Codelyzer.Analysis.Build
             List<string> editions = new List<string> { "Enterprise", "Professional", "Community", "BuildTools" };
             var targets = new string[] { "Microsoft.CSharp.targets", "Microsoft.CSharp.CurrentVersion.targets", "Microsoft.Common.targets" };
             // "Microsoft.CSharp.CrossTargeting.targets"
+
             var msbuildpath = "";
+            DirectoryInfo vsDirectory;
+#if NET6_0_OR_GREATER
             //2022
             var programFiles = programFilesPath ?? Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
-            DirectoryInfo vsDirectory = new DirectoryInfo(Path.Combine(programFiles, "Microsoft Visual Studio"));
+            vsDirectory = new DirectoryInfo(Path.Combine(programFiles, "Microsoft Visual Studio"));
             msbuildpath = GetMsBuildPathFromVSDirectory(vsDirectory, editions, targets);
             if (!String.IsNullOrEmpty(msbuildpath)) return msbuildpath;
-
+#endif
             // 2019, 2017
             string programFilesX86 = programFilesX86Path?? System.Environment.GetFolderPath(System.Environment.SpecialFolder.ProgramFilesX86);
             vsDirectory = new DirectoryInfo(Path.Combine(programFilesX86, "Microsoft Visual Studio"));

--- a/tst/Codelyzer.Analysis.Tests/WorkspaceBuilderHelperTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/WorkspaceBuilderHelperTests.cs
@@ -111,9 +111,16 @@ namespace Codelyzer.Analysis.Tests
         [Test]
         public void TestVS2022()
         {
+#if NET6_0_OR_GREATER
             string actualMsBuildPath = Path.Combine(testvs2022Path, Constants.vs2022MSBuildPath);
             string msbuildpath = WorkspaceBuilderHelper.GetFrameworkMsBuildExePath(programFilesPath: Path.Combine(testvs2022Path, Constants.programFiles), programFilesX86Path: Path.Combine(testvs2022Path, Constants.programFilesx86));
             Assert.AreEqual(actualMsBuildPath,msbuildpath);
+#else
+            // Fall back to VS2019 if it is available and if targeting below .NET 6
+            string actualMsBuildPath = Path.Combine(testvs2019Path, Constants.vs2019MSBuildPath);
+            string msbuildpath = WorkspaceBuilderHelper.GetFrameworkMsBuildExePath(programFilesPath: Path.Combine(testvs2019Path, Constants.programFiles), programFilesX86Path: Path.Combine(testvs2019Path, Constants.programFilesx86));
+            Assert.AreEqual(actualMsBuildPath, msbuildpath);
+#endif
         }
 
         [Test]


### PR DESCRIPTION
## Related issue

Closes: #ISSUE_NUMBER_HERE


## Description
* Prevents calling a version of MSBuild that is incompatible with Codelyzer's target framework

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
