### PR TITLE
Reduce test run duration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ TestResult.xml
 # Test project directory
 **/Projects/Temp/
 
+# Test project downloads directory
+**/Projects/Downloads/
+
 # Build Results of an ATL Project
 [Dd]ebugPS/
 [Rr]eleasePS/

--- a/src/Analysis/Codelyzer.Analysis.Common/FileUtils.cs
+++ b/src/Analysis/Codelyzer.Analysis.Common/FileUtils.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -25,11 +24,6 @@ namespace Codelyzer.Analysis.Common
         {
             return File.ReadAllText(pathFile);
         }
-
-        public static void CreateDirectory(string path)
-        {
-            System.IO.Directory.CreateDirectory(path);
-        }
         
         public static string GetRelativePath(string filePath, string dirPath)
         {
@@ -38,6 +32,41 @@ namespace Codelyzer.Analysis.Common
             
             var path = filePath.Replace(dirPathSeparator, "");
             return path;
+        }
+
+        public static void DirectoryCopy(string sourceDirName, string destDirName, bool copySubDirs = true)
+        {
+            // Get the subdirectories for the specified directory.
+            DirectoryInfo dir = new DirectoryInfo(sourceDirName);
+            if (!dir.Exists)
+            {
+                throw new DirectoryNotFoundException(
+                    "Source directory does not exist or could not be found: "
+                    + sourceDirName);
+            }
+
+            DirectoryInfo[] dirs = dir.GetDirectories();
+
+            // If the destination directory doesn't exist, create it.       
+            Directory.CreateDirectory(destDirName);
+
+            // Get the files in the directory and copy them to the new location.
+            FileInfo[] files = dir.GetFiles();
+            foreach (FileInfo file in files)
+            {
+                string tempPath = Path.Combine(destDirName, file.Name);
+                file.CopyTo(tempPath, false);
+            }
+
+            // If copying subdirectories, copy them and their contents to new location.
+            if (copySubDirs)
+            {
+                foreach (DirectoryInfo subdir in dirs)
+                {
+                    string tempPath = Path.Combine(destDirName, subdir.Name);
+                    DirectoryCopy(subdir.FullName, tempPath, copySubDirs);
+                }
+            }
         }
     }
 }

--- a/src/Analysis/Codelyzer.Analysis.Common/FileUtils.cs
+++ b/src/Analysis/Codelyzer.Analysis.Common/FileUtils.cs
@@ -34,27 +34,27 @@ namespace Codelyzer.Analysis.Common
             return path;
         }
 
-        public static void DirectoryCopy(string sourceDirName, string destDirName, bool copySubDirs = true)
+        public static void DirectoryCopy(string sourceDirPath, string destDirPath, bool copySubDirs = true)
         {
             // Get the subdirectories for the specified directory.
-            DirectoryInfo dir = new DirectoryInfo(sourceDirName);
+            DirectoryInfo dir = new DirectoryInfo(sourceDirPath);
             if (!dir.Exists)
             {
                 throw new DirectoryNotFoundException(
                     "Source directory does not exist or could not be found: "
-                    + sourceDirName);
+                    + sourceDirPath);
             }
 
             DirectoryInfo[] dirs = dir.GetDirectories();
 
             // If the destination directory doesn't exist, create it.       
-            Directory.CreateDirectory(destDirName);
+            Directory.CreateDirectory(destDirPath);
 
             // Get the files in the directory and copy them to the new location.
             FileInfo[] files = dir.GetFiles();
             foreach (FileInfo file in files)
             {
-                string tempPath = Path.Combine(destDirName, file.Name);
+                string tempPath = Path.Combine(destDirPath, file.Name);
                 file.CopyTo(tempPath, false);
             }
 
@@ -63,7 +63,7 @@ namespace Codelyzer.Analysis.Common
             {
                 foreach (DirectoryInfo subdir in dirs)
                 {
-                    string tempPath = Path.Combine(destDirName, subdir.Name);
+                    string tempPath = Path.Combine(destDirPath, subdir.Name);
                     DirectoryCopy(subdir.FullName, tempPath, copySubDirs);
                 }
             }

--- a/src/Analysis/Codelyzer.Analysis/CSharpCodeAnalyzer.cs
+++ b/src/Analysis/Codelyzer.Analysis/CSharpCodeAnalyzer.cs
@@ -4,7 +4,6 @@ using Codelyzer.Analysis.CSharp;
 using Codelyzer.Analysis.Model;
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Logging;
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -181,7 +180,7 @@ namespace Codelyzer.Analysis
         {
             if (AnalyzerConfiguration.ExportSettings.GenerateJsonOutput)
             {
-                FileUtils.CreateDirectory(AnalyzerConfiguration.ExportSettings.OutputPath);
+                Directory.CreateDirectory(AnalyzerConfiguration.ExportSettings.OutputPath);
                 foreach (var analyzerResult in analyzerResults)
                 {
                     Logger.LogDebug("Generating Json file for " + analyzerResult.ProjectResult.ProjectName);

--- a/src/Codelyzer.sln.DotSettings
+++ b/src/Codelyzer.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Codelyzer/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
@@ -20,24 +20,34 @@ namespace Codelyzer.Analysis.Tests
     [NonParallelizable]
     public class AwsAnalyzerTests : AwsBaseTest
     {
-        public string tempDir = "";
+        public string downloadsDir = ""; // A place to download example solutions one time for all tests
+        public string tempDir = ""; // A place to copy example solutions for each test (as needed)
 
-        [SetUp]
-        public void Setup()
+        [OneTimeSetUp]
+        public void OneTimeSetup()
         {
             Setup(GetType());
             tempDir = GetTstPath(Path.Combine(Constants.TempProjectDirectories));
+            downloadsDir = GetTstPath(Path.Combine(Constants.TempProjectDownloadDirectories));
+            DeleteDir(tempDir);
+            DeleteDir(downloadsDir);
+            Directory.CreateDirectory(tempDir);
+            Directory.CreateDirectory(downloadsDir);
             DownloadTestProjects();
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            DeleteDir(tempDir);
+            DeleteDir(downloadsDir);
         }
 
         private void DownloadTestProjects()
         {
-            var tempDirectory = Directory.CreateDirectory(tempDir);
-
             DownloadFromGitHub(@"https://github.com/FabianGosebrink/ASPNET-WebAPI-Sample/archive/671a629cab0382ecd6dec4833b3868f96f89da50.zip", "ASPNET-WebAPI-Sample-671a629cab0382ecd6dec4833b3868f96f89da50");
             DownloadFromGitHub(@"https://github.com/Duikmeester/MvcMusicStore/archive/e274968f2827c04cfefbe6493f0a784473f83f80.zip", "MvcMusicStore-e274968f2827c04cfefbe6493f0a784473f83f80");
             DownloadFromGitHub(@"https://github.com/nopSolutions/nopCommerce/archive/73567858b3e3ef281d1433d7ac79295ebed47ee6.zip", "nopCommerce-73567858b3e3ef281d1433d7ac79295ebed47ee6");
-
         }
 
         private void DownloadFromGitHub(string link, string name)
@@ -45,10 +55,9 @@ namespace Codelyzer.Analysis.Tests
             using (var client = new HttpClient())
             {
                 var content = client.GetByteArrayAsync(link).Result;
-                var tempDirectory = Directory.CreateDirectory(GetTstPath(Path.Combine(new string[] { "Projects", "Temp" })));
-                var fileName = string.Concat(tempDirectory.FullName, name, @".zip");
+                var fileName = Path.Combine(downloadsDir, string.Concat(name, @".zip"));
                 File.WriteAllBytes(fileName, content);
-                ZipFile.ExtractToDirectory(fileName, tempDirectory.FullName, true);
+                ZipFile.ExtractToDirectory(fileName, downloadsDir, true);
                 File.Delete(fileName);
             }
         }
@@ -56,7 +65,7 @@ namespace Codelyzer.Analysis.Tests
         [Test]
         public void TestCli()
         {
-            string mvcMusicStorePath = Directory.EnumerateFiles(tempDir, "MvcMusicStore.sln", SearchOption.AllDirectories).FirstOrDefault();
+            string mvcMusicStorePath = Directory.EnumerateFiles(downloadsDir, "MvcMusicStore.sln", SearchOption.AllDirectories).FirstOrDefault();
             string[] args = { "-p", mvcMusicStorePath };
             AnalyzerCLI cli = new AnalyzerCLI();
             cli.HandleCommand(args);
@@ -121,10 +130,10 @@ namespace Codelyzer.Analysis.Tests
 
         private string CopySolutionFolderToTemp(string solutionName)
         {
-            string solutionPath = Directory.EnumerateFiles(tempDir, solutionName, SearchOption.AllDirectories).FirstOrDefault();
+            string solutionPath = Directory.EnumerateFiles(downloadsDir, solutionName, SearchOption.AllDirectories).FirstOrDefault();
             string solutionDir = Directory.GetParent(solutionPath).FullName;
-            var newTempDir = Path.Combine(Directory.GetParent(solutionDir).FullName, Guid.NewGuid().ToString());
-            CopyDirectory(new DirectoryInfo(solutionDir), new DirectoryInfo(newTempDir));
+            var newTempDir = Path.Combine(tempDir, Guid.NewGuid().ToString());
+            FileUtils.DirectoryCopy(solutionDir, newTempDir);
 
             solutionPath = Directory.EnumerateFiles(newTempDir, solutionName, SearchOption.AllDirectories).FirstOrDefault();
             return solutionPath;
@@ -733,7 +742,7 @@ namespace Mvc3ToolsUpdateWeb_Default.Controllers
         [Test]
         public async Task TestNopCommerce()
         {
-            string solutionPath = Directory.EnumerateFiles(tempDir, "nopCommerce.sln", SearchOption.AllDirectories).FirstOrDefault();
+            string solutionPath = Directory.EnumerateFiles(downloadsDir, "nopCommerce.sln", SearchOption.AllDirectories).FirstOrDefault();
             FileAssert.Exists(solutionPath);
 
             AnalyzerConfiguration configuration = new AnalyzerConfiguration(LanguageOptions.CSharp)
@@ -904,25 +913,22 @@ namespace Mvc3ToolsUpdateWeb_Default.Controllers
             });
         }
 
-        [TearDown]
-        public void Cleanup()
-        {
-            DeleteDir(0);
-        }
-
         #region private methods
-        private void DeleteDir(int retries)
+        private void DeleteDir(string path, int retries = 0)
         {
             if(retries <= 10)
             {
                 try
                 {
-                    Directory.Delete(GetTstPath(Path.Combine("Projects", "Temp")), true);
+                    if (Directory.Exists(path))
+                    {
+                        Directory.Delete(path, true);
+                    }
                 }
                 catch (Exception)
                 {
                     Thread.Sleep(10000);
-                    DeleteDir(retries + 1);
+                    DeleteDir(path, retries + 1);
                 }
             }
         }

--- a/tst/Codelyzer.Analysis.Tests/AwsBaseTest.cs
+++ b/tst/Codelyzer.Analysis.Tests/AwsBaseTest.cs
@@ -43,28 +43,5 @@ namespace Codelyzer.Analysis.Tests
         {
             return Path.Combine(srcPath, path);
         }
-
-        protected void CopyDirectory(DirectoryInfo source, DirectoryInfo target)
-        {
-            if (!Directory.Exists(target.FullName))
-            {
-                Directory.CreateDirectory(target.FullName);
-            }
-
-            var files = source.GetFiles();
-            foreach (var file in files)
-            {
-                file.CopyTo(Path.Combine(target.FullName, file.Name), true);
-            }
-
-            var dirs = source.GetDirectories();
-            foreach (var dir in dirs)
-            {
-                DirectoryInfo destinationSub = new DirectoryInfo(Path.Combine(target.FullName, dir.Name));
-                CopyDirectory(dir, destinationSub);
-            }
-        }
     }
-    
-    
 }

--- a/tst/Codelyzer.Analysis.Tests/Codelyzer.Analysis.Tests.csproj
+++ b/tst/Codelyzer.Analysis.Tests/Codelyzer.Analysis.Tests.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <IsTestProject>true</IsTestProject>
         <IsPackable>false</IsPackable>
-        <RootNamespace>AwsCodeAnalyzerTests</RootNamespace>
+        <RootNamespace>Codelyzer.Analysis.Tests</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>

--- a/tst/Codelyzer.Analysis.Tests/Constants.cs
+++ b/tst/Codelyzer.Analysis.Tests/Constants.cs
@@ -2,9 +2,12 @@
 {
     internal class Constants
     {
-        // Do not change these values without updating the corresponding line in .gitignore:  **/Projects/Temp
+        // Do not change these values without updating the corresponding line in .gitignore:
+        //  **/Projects/Temp
+        //  **/Projects/Downloads
         // This is to prevent test projects from being picked up in git after failed unit tests.
         internal static readonly string[] TempProjectDirectories = { "Projects", "Temp" };
+        internal static readonly string[] TempProjectDownloadDirectories = { "Projects", "Downloads" };
 
         internal static string programFiles = "Program Files";
         internal static string programFilesx86 = "Program Files (x86)";

--- a/tst/Codelyzer.Analysis.Tests/FileUtilsTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/FileUtilsTests.cs
@@ -1,0 +1,101 @@
+﻿using System.IO;
+using Codelyzer.Analysis.Common;
+using NUnit.Framework;
+
+namespace Codelyzer.Analysis.Tests
+{
+    [TestFixture]
+    public class FileUtilsTests
+    {
+        private const string SourceDirPath = "FileUtilsTests_SourceDir";
+        private const string DestDirPath = "FileUtilsTests_DestDir";
+
+        [SetUp]
+        public void SetUp()
+        {
+            RemoveTestDirs();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            RemoveTestDirs();
+        }
+
+        private static void RemoveTestDirs()
+        {
+            if (Directory.Exists(DestDirPath))
+            {
+                Directory.Delete(DestDirPath, true);
+            }
+            if (Directory.Exists(SourceDirPath))
+            {
+                Directory.Delete(SourceDirPath, true);
+            }
+        }
+
+        [Test]
+        public void DirectoryCopy_CreatesNewDirectory_IfDestDoesNotExists()
+        {
+            // Arrange
+            Directory.CreateDirectory(SourceDirPath);
+            if (Directory.Exists(DestDirPath))
+            {
+                Directory.Delete(DestDirPath);
+            }
+
+            // Act
+            FileUtils.DirectoryCopy(SourceDirPath, DestDirPath, false);
+
+            // Assert
+            Directory.Exists(DestDirPath);
+        }
+
+        [Test]
+        public void DirectoryCopy_Throws_IfSourceDoesNotExists()
+        {
+            // Arrange
+            if (Directory.Exists(SourceDirPath))
+            {
+                Directory.Delete(SourceDirPath);
+            }
+
+            // Act & Assert
+            Assert.Throws<DirectoryNotFoundException>(() => FileUtils.DirectoryCopy(SourceDirPath, DestDirPath, false));
+        }
+
+        [Test]
+        public void DirectoryCopy_CopiesContainedFiles()
+        {
+            // Arrange
+            const string testFileName = "testFile.txt";
+            Directory.CreateDirectory(SourceDirPath);
+            var filePath = Path.Combine(SourceDirPath, testFileName);
+            File.Create(filePath).Dispose();
+
+            // Act
+            FileUtils.DirectoryCopy(SourceDirPath, DestDirPath, true);
+
+            // Assert
+            Assert.IsTrue(File.Exists(Path.Combine(DestDirPath, testFileName)));
+        }
+
+        [Test]
+        public void DirectoryCopy_CopiesSubFolders()
+        {
+            // Arrange
+            const string subFolderName = "SubFolder";
+            const string testFileName = "testFile.txt";
+            Directory.CreateDirectory(SourceDirPath);
+            var subDir = Directory.CreateDirectory(Path.Combine(SourceDirPath, subFolderName)).FullName;
+            var filePath = Path.Combine(subDir, testFileName);
+            File.Create(filePath).Dispose();
+
+            // Act
+            FileUtils.DirectoryCopy(SourceDirPath, DestDirPath, true);
+
+            // Assert
+            Assert.IsTrue(File.Exists(Path.Combine(DestDirPath, subFolderName, testFileName)));
+        }
+    }
+}


### PR DESCRIPTION
## Description
* Before this change, the tests would download the example solutions multiple times in a test run. Now, they are downloaded once and then copied to temp folders as needed.
* Reduces full-repository test run duration from around 10 minutes to around 3 minutes (on my local laptop at least)

## Supplemental testing
Ran command line against test solution

## Additional context
If we want, I can go further with this and create something like a lazy-loaded example solution factory that could potentially be used with CTA and other repositories. 

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
