### PR TITLE
Downgrading Microsoft.CodeAnalysis for now to fix OwinTests

### DIFF
--- a/src/Analysis/Codelyzer.Analysis.Model/Codelyzer.Analysis.Model.csproj
+++ b/src/Analysis/Codelyzer.Analysis.Model/Codelyzer.Analysis.Model.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.CodeAnalysis" Version="4.0.1" />
-      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
+      <PackageReference Include="Microsoft.CodeAnalysis" Version="3.11.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     </ItemGroup>


### PR DESCRIPTION
## Related issue
Closes: Issue reproduced here: https://github.com/aws/codelyzer/pull/134/files 

## Description
* It seems that this package upgrade had a breaking change that breaks our code in CTA for at least 1 case. We are reverting this package until we can get the bug fixed in version 4 of Microsoft.CodeAnalysis or understand a better work around. 

## Supplemental testing
Ran with repro PR listed above

## Additional context
We will need to release this as a new package so that CTA can finish upgrading to .NET 6. The last published version of codelyzer (2.0.3) has this bug.

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
