### PR TITLE
make sure only accepted project types are returned

### DIFF
--- a/src/Analysis/Codelyzer.Analysis.Build/WorkspaceBuilderHelper.cs
+++ b/src/Analysis/Codelyzer.Analysis.Build/WorkspaceBuilderHelper.cs
@@ -35,13 +35,6 @@ namespace Codelyzer.Analysis.Build
         private Dictionary<Guid, IAnalyzerResult> DictAnalysisResult;
         private ILogger Logger { get; set; }
 
-        private static HashSet<SolutionProjectType> AcceptedProjectTypes = new HashSet<SolutionProjectType>()
-        {
-            SolutionProjectType.KnownToBeMSBuildFormat,
-            SolutionProjectType.WebDeploymentProject,
-            SolutionProjectType.WebProject
-        };
-
         public WorkspaceBuilderHelper(ILogger logger, string workspacePath, AnalyzerConfiguration analyzerConfiguration = null)
         {
             this.Logger = logger;
@@ -65,7 +58,7 @@ namespace Codelyzer.Analysis.Build
 
         private bool IsProjectFile(ProjectInSolution project)
         {
-            return AcceptedProjectTypes.Contains(project.ProjectType);
+            return Constants.AcceptedProjectTypes.Contains(project.ProjectType);
         }
 
         public async IAsyncEnumerable<ProjectAnalysisResult> BuildProjectIncremental()

--- a/src/Analysis/Codelyzer.Analysis.Common/Constants.cs
+++ b/src/Analysis/Codelyzer.Analysis.Common/Constants.cs
@@ -1,4 +1,6 @@
-﻿using System.IO;
+﻿using Microsoft.Build.Construction;
+using System.Collections.Generic;
+using System.IO;
 
 namespace Codelyzer.Analysis.Common
 {
@@ -19,6 +21,13 @@ namespace Codelyzer.Analysis.Common
         public const string PackagesFolder = "packages";
         public const string NupkgFileExtension = "*.nupkg";
         public const string PackagesConfig = "packages.config";
+
+        public static HashSet<SolutionProjectType> AcceptedProjectTypes = new HashSet<SolutionProjectType>()
+        {
+            SolutionProjectType.KnownToBeMSBuildFormat,
+            SolutionProjectType.WebDeploymentProject,
+            SolutionProjectType.WebProject
+        };
 
         public static string PackagesDirectoryIdentifier
         {

--- a/src/Analysis/Codelyzer.Analysis.Common/FileUtils.cs
+++ b/src/Analysis/Codelyzer.Analysis.Common/FileUtils.cs
@@ -88,7 +88,7 @@ namespace Codelyzer.Analysis.Common
                 try
                 {
                     SolutionFile solution = SolutionFile.Parse(solutionPath);
-                    projectPaths = solution.ProjectsInOrder.Select(p => p.AbsolutePath);
+                    projectPaths = solution.ProjectsInOrder.Where(p => Constants.AcceptedProjectTypes.Contains(p.ProjectType)).Select(p => p.AbsolutePath);
                 }
                 catch (Exception ex)
                 {

--- a/tst/Codelyzer.Analysis.Tests/FileUtilsTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/FileUtilsTests.cs
@@ -121,7 +121,7 @@ namespace Codelyzer.Analysis.Tests
 
             // Assert
             Assert.IsNotNull(results);
-            Assert.IsTrue(results.Count() == 6);
+            Assert.IsTrue(results.Count() == 5);
         }
 
         [Test]


### PR DESCRIPTION
## Related issue

Closes: #126 


## Description
Ensure we only return accepted project types as well as only build buildable ones (already did second part of this)

## Supplemental testing
Describe any testing done in addition to existing unit tests

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
