### PR TITLE
Updating packages. Remove language version argument

### DIFF
--- a/src/Analysis/Codelyzer.Analysis.Build/Codelyzer.Analysis.Build.csproj
+++ b/src/Analysis/Codelyzer.Analysis.Build/Codelyzer.Analysis.Build.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Buildalyzer" Version="3.2.5" />
-      <PackageReference Include="Buildalyzer.Logger" Version="3.2.5" />
-      <PackageReference Include="Buildalyzer.Workspaces" Version="3.2.5" />
+      <PackageReference Include="Buildalyzer" Version="3.2.8" />
+      <PackageReference Include="Buildalyzer.Logger" Version="3.2.8" />
+      <PackageReference Include="Buildalyzer.Workspaces" Version="3.2.8" />
       <PackageReference Include="NuGet.Packaging" Version="6.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     </ItemGroup>
@@ -19,7 +19,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.244" />
+      <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+      <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.255" />
     </ItemGroup>
 
 </Project>

--- a/src/Analysis/Codelyzer.Analysis.Build/ProjectBuildHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.Build/ProjectBuildHandler.cs
@@ -437,8 +437,14 @@ namespace Codelyzer.Analysis.Build
         {
             await Task.Run(() =>
             {
+                var languageVersion = LanguageVersion.Default;
+                if (projectBuildResult.Compilation is CSharpCompilation compilation)
+                {
+                    languageVersion = compilation.LanguageVersion;
+                }
+
                 var fileContents = File.ReadAllText(filePath);
-                var updatedTree = CSharpSyntaxTree.ParseText(SourceText.From(fileContents), path: filePath);
+                var updatedTree = CSharpSyntaxTree.ParseText(SourceText.From(fileContents), path: filePath, options: new CSharpParseOptions(languageVersion));
 
                 var syntaxTree = Compilation.SyntaxTrees.FirstOrDefault(syntaxTree => syntaxTree.FilePath == filePath);
                 var preportSyntaxTree = Compilation.SyntaxTrees.FirstOrDefault(syntaxTree => syntaxTree.FilePath == filePath);

--- a/src/Analysis/Codelyzer.Analysis.Build/WorkspaceBuilderHelper.cs
+++ b/src/Analysis/Codelyzer.Analysis.Build/WorkspaceBuilderHelper.cs
@@ -502,8 +502,6 @@ namespace Codelyzer.Analysis.Build
             options.EnvironmentVariables.Add(Constants.EnableNuGetPackageRestore, Boolean.TrueString.ToLower());
 
             options.Arguments.Add(Constants.RestorePackagesConfigArgument);
-            options.Arguments.Add(Constants.LanguageVersionArgument);
-
             if (_analyzerConfiguration.MetaDataSettings.GenerateBinFiles)
             {
                 options.GlobalProperties.Add(MsBuildProperties.CopyBuildOutputToOutputDirectory, "true");

--- a/src/Analysis/Codelyzer.Analysis.CSharp/Codelyzer.Analysis.CSharp.csproj
+++ b/src/Analysis/Codelyzer.Analysis.CSharp/Codelyzer.Analysis.CSharp.csproj
@@ -12,7 +12,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.244" />
+      <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+      <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.255" />
     </ItemGroup>
 
 </Project>

--- a/src/Analysis/Codelyzer.Analysis.Common/Codelyzer.Analysis.Common.csproj
+++ b/src/Analysis/Codelyzer.Analysis.Common/Codelyzer.Analysis.Common.csproj
@@ -16,7 +16,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.244" />
+      <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+      <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.255" />
     </ItemGroup>
 
 </Project>

--- a/src/Analysis/Codelyzer.Analysis.Common/Constants.cs
+++ b/src/Analysis/Codelyzer.Analysis.Common/Constants.cs
@@ -11,7 +11,6 @@ namespace Codelyzer.Analysis.Common
         public const int DefaultConcurrentThreads = 4;
         public const string MsBuildCommandName = "msbuild";
         public const string RestorePackagesConfigArgument = "/p:RestorePackagesConfig=true";
-        public const string LanguageVersionArgument = "/p:langversion=latest";
         public const string EnableNuGetPackageRestore = "EnableNuGetPackageRestore";
             
         public const string ProjectReferenceType = "Microsoft.CodeAnalysis.CSharp.CSharpCompilationReference";

--- a/src/Analysis/Codelyzer.Analysis.Model/Codelyzer.Analysis.Model.csproj
+++ b/src/Analysis/Codelyzer.Analysis.Model/Codelyzer.Analysis.Model.csproj
@@ -7,14 +7,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.CodeAnalysis" Version="3.11.0" />
-      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis" Version="4.0.1" />
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.244" />
+      <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+      <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.255" />
     </ItemGroup>
 
 </Project>

--- a/src/Analysis/Codelyzer.Analysis/Codelyzer.Analysis.csproj
+++ b/src/Analysis/Codelyzer.Analysis/Codelyzer.Analysis.csproj
@@ -18,7 +18,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.244" />
+      <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+      <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.255" />
     </ItemGroup>
 
 </Project>

--- a/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
@@ -258,8 +258,8 @@ namespace Codelyzer.Analysis.Tests
             File.WriteAllText(projectPath, projectFileContent.Replace(@"$(MSBuildBinPath)\Microsoft.CSharp.targets", @"InvalidTarget"));
 
             //Try without setting the flag, result should be null:
-            AnalyzerResult result = (await analyzer.AnalyzeSolution(solutionPath)).FirstOrDefault();
-            Assert.Null(result);
+            AnalyzerResult result = (await analyzer.AnalyzeSolution(solutionPath)).First();
+            Assert.IsTrue(result.ProjectBuildResult.BuildErrors.Count > 0);
 
             //Try with setting the flag, syntax tree should be returned
             configuration.AnalyzeFailedProjects = true;

--- a/tst/Codelyzer.Analysis.Tests/Codelyzer.Analysis.Tests.csproj
+++ b/tst/Codelyzer.Analysis.Tests/Codelyzer.Analysis.Tests.csproj
@@ -13,13 +13,17 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="nunit" Version="3.13.2" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
         <PackageReference Include="Moq" Version="4.16.1" />
     </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\..\src\Analysis\Codelyzer.Analysis\Codelyzer.Analysis.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Description
* Updating packages. The main point of this was actually to update Microsoft.CodeAnalysis which was left un-updated in the last release due to a breaking change. To resolve our issue with the breaking change, we've removed the langVersion argument that gets passed to MsBuild. It seems like a small change, but now we're letting MsBuild decide the language version of the code it's building rather than always using the latest language that that version of MsBuild knows. So for example, now a 4.7.3 .NET framework will be analyzed with C# 7.3 instead of C# 10. 

This will unblock the CTA .NET 6 upgrade. 

## Supplemental testing
Also validated that all CTA tests pass when using this package

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
