### PR TITLE
Add development requirements to readme and update build_test.yml

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2019
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
@@ -27,25 +27,19 @@ jobs:
           echo "Added aws secret templates"
           git secrets --scan -r ../
           echo "Repository scan completed"
-    - name: Setup .NET Core
+    - name: Setup .NET Versions
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.301
-    - name: Setup .NET 5
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 5.0.x
-    - name: Setup .NET 6
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 6.0.x
-        include-prerelease: true
+        dotnet-version: | 
+          3.1.x
+          5.0.x
+          6.0.x
     - name: Install dependencies
       run: dotnet restore src/Codelyzer.sln
     - name: Build
       run: dotnet build --configuration Release --no-restore src/Codelyzer.sln
     - name: Test
-      run: dotnet test --configuration Release --no-restore --verbosity normal src/Codelyzer.sln
+      run: dotnet test --configuration Release --no-build --no-restore --verbosity normal src/Codelyzer.sln
     - name: Pack
       if: ${{ github.event_name == 'push' }}
       run: dotnet pack --configuration Release --no-restore -o dist src/Codelyzer.sln

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ var allMethods = sourcefile.AllMethods();
 var allLiterals = sourcefile.AllLiterals();
 ```
 
-## How to use this code?
-* Clone the Git repository.
+## How to run this code
+* Clone the repository `git clone https://github.com/aws/codelyzer.git`
 * Load the solution `Codelyzer.sln` using Visual Studio or Rider. 
 * Create a "Run/Debug" Configuration for the "Codelyzer.Analysis" project.
 * Provide command line arguments for a solution and output path, then run the application.
@@ -70,6 +70,19 @@ for tracking bugs and feature requests.
 We welcome community contributions and pull requests. See
 [CONTRIBUTING](./CONTRIBUTING.md) for information on how to set up a development
 environment and submit code.
+
+### How to build this code and run automated tests successfully
+* Clone the repository `git clone https://github.com/aws/codelyzer.git`
+* You'll need BOTH Visual Studio 2022 and 2019. 2019 is needed to bring in the required dependencies for some tests.
+* Install Visual Studio 2022 with:
+  * The `.NET desktop development` Workload
+  * The `ASP.NET and web development` Workload
+  * The `ASP.NET MVC 4` Individual Component
+* Install Visual Studio 2019 with:
+  * The `ASP.NET and web development` Workload
+* Load the solution `Codelyzer.sln` using Visual Studio 2022. 
+* Build
+* Run tests
 
 ## Thank you
 * [The .NET Compiler Platform ("Roslyn")](https://github.com/dotnet/roslyn) - Roslyn provides open-source C# and Visual Basic compilers with rich code analysis APIs.   

--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ environment and submit code.
 * Clone the repository `git clone https://github.com/aws/codelyzer.git`
 * You'll need BOTH Visual Studio 2022 and 2019. 2019 is needed to bring in the required dependencies for some tests.
 * Install Visual Studio 2022 with:
-  * The `.NET desktop development` Workload
-  * The `ASP.NET and web development` Workload
+  * The `.NET Desktop Development` Workload
+  * The `ASP.NET and Web Development` Workload
   * The `ASP.NET MVC 4` Individual Component
 * Install Visual Studio 2019 with:
-  * The `ASP.NET and web development` Workload
+  * The `ASP.NET and Web Development` Workload
 * Load the solution `Codelyzer.sln` using Visual Studio 2022. 
 * Build
 * Run tests

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ environment and submit code.
 
 ### How to build this code and run automated tests successfully
 * Clone the repository `git clone https://github.com/aws/codelyzer.git`
-* You'll need BOTH Visual Studio 2022 and 2019. 2019 is needed to bring in the required dependencies for some tests.
+* You'll need BOTH Visual Studio 2022 and 2019. 2019 is needed to bring in the required dependencies for some tests. Community, Professional and Enterprise Edition all work.
 * Install Visual Studio 2022 with:
   * The `.NET Desktop Development` Workload
   * The `ASP.NET and Web Development` Workload

--- a/tst/Codelyzer.Analysis.Tests/ProjectBuildHandlerTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/ProjectBuildHandlerTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Xml.Linq;
 using Codelyzer.Analysis.Build;
@@ -17,28 +18,28 @@ namespace Codelyzer.Analysis.Tests
         [OneTimeSetUp]
         public virtual void OneTimeSetUp()
         {
-            projectFileContent = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-  </PropertyGroup>
-  <ItemGroup>
-    <FrameworkReference Include=""Microsoft.AspNetCore.App"" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include=""MyFirstPackage"" Version=""1.0.0"" />
-    <PackageReference Include=""MySecondPackage"" Version=""2.0.0"" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include=""TheMainProject"" />
-    <ProjectReference Include=""TheDependency"" />
-  </ItemGroup>
-  <ItemGroup Label=""PortingInfo"">
-    <!-- DO NOT REMOVE WHILE PORTING
-        C:\\RandomFile.dll
-        C:\\this\\is\\some\\path\\to\\Some.dll
-    -->
-  </ItemGroup>
-</Project>";
+            projectFileContent = @"<Project Sdk=""Microsoft.NET.Sdk"">" + Environment.NewLine + 
+@"  <PropertyGroup>" + Environment.NewLine + 
+@"    <TargetFramework>netcoreapp3.1</TargetFramework>" + Environment.NewLine + 
+@"  </PropertyGroup>" + Environment.NewLine + 
+@"  <ItemGroup>" + Environment.NewLine + 
+@"    <FrameworkReference Include=""Microsoft.AspNetCore.App"" />" + Environment.NewLine + 
+@"  </ItemGroup>" + Environment.NewLine + 
+@"  <ItemGroup>" + Environment.NewLine + 
+@"    <PackageReference Include=""MyFirstPackage"" Version=""1.0.0"" />" + Environment.NewLine + 
+@"    <PackageReference Include=""MySecondPackage"" Version=""2.0.0"" />" + Environment.NewLine + 
+@"  </ItemGroup>" + Environment.NewLine + 
+@"  <ItemGroup>" + Environment.NewLine + 
+@"    <ProjectReference Include=""TheMainProject"" />" + Environment.NewLine + 
+@"    <ProjectReference Include=""TheDependency"" />" + Environment.NewLine + 
+@"  </ItemGroup>" + Environment.NewLine + 
+@"  <ItemGroup Label=""PortingInfo"">" + Environment.NewLine + 
+@"    <!-- DO NOT REMOVE WHILE PORTING" + Environment.NewLine + 
+@"        C:\\RandomFile.dll" + Environment.NewLine + 
+@"        C:\\this\\is\\some\\path\\to\\Some.dll" + Environment.NewLine + 
+@"    -->" + Environment.NewLine +
+@"  </ItemGroup>" + Environment.NewLine +
+@"</Project>";
             tmpTestFixturePath = Path.GetFullPath(Path.Combine(
                 Path.GetTempPath(),
                 Path.GetRandomFileName()));


### PR DESCRIPTION
## Description
* As part of getting started working on this repository I had some issues getting everything setup and running correctly, so I wanted to document what exactly is need to build and run all tests.
* I also added the Environment.NewLine changes so that if someone downloads this as a zip from GitHub to Windows (or doesn't have git core.autoCRLF=true) the tests will still pass
* Lastly, it seems like GitHub Actions' breaking change of defaulting to windows 2022 broke our tests. For now, specifying 2019 works, but it would be nice to eventually get things to work on 2022. Unfortunately that probably means manually installing old .NET Framework dependencies (probably the same ones that come with VS2019)
  * https://github.com/actions/virtual-environments/issues/4856

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
