### PR TITLE
set dependabot to weekly schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
       - porting-assistant-nuget
       - nuget-org
     schedule:
-      interval: "daily"
+      interval: "weekly"
 updates:
   - package-ecosystem: "nuget"
     directory: "/src/Analysis/Codelyzer.Analysis.Build"
@@ -21,7 +21,7 @@ updates:
       - porting-assistant-nuget
       - nuget-org
     schedule:
-      interval: "daily"
+      interval: "weekly"
     ignore:
       - dependency-name: "Buildalyzer*"
 updates:
@@ -31,7 +31,7 @@ updates:
       - porting-assistant-nuget
       - nuget-org
     schedule:
-      interval: "daily"
+      interval: "weekly"
 updates:
   - package-ecosystem: "nuget"
     directory: "/src/Analysis/Codelyzer.Analysis.CSharp"
@@ -39,7 +39,7 @@ updates:
       - porting-assistant-nuget
       - nuget-org
     schedule:
-      interval: "daily"
+      interval: "weekly"
 updates:
   - package-ecosystem: "nuget"
     directory: "/src/Analysis/Codelyzer.Analysis.Model"
@@ -47,7 +47,7 @@ updates:
       - porting-assistant-nuget
       - nuget-org
     schedule:
-      interval: "daily"
+      interval: "weekly"
 updates:
   - package-ecosystem: "nuget"
     directory: "/tst/Codelyzer.Analysis.Tests"
@@ -55,6 +55,6 @@ updates:
       - porting-assistant-nuget
       - nuget-org
     schedule:
-      interval: "daily"
+      interval: "weekly"
     ignore:
       - dependency-name: "Buildalyzer*"      

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,8 +22,6 @@ updates:
       - nuget-org
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "Buildalyzer*"
 updates:
   - package-ecosystem: "nuget"
     directory: "/src/Analysis/Codelyzer.Analysis.Common"
@@ -55,6 +53,4 @@ updates:
       - porting-assistant-nuget
       - nuget-org
     schedule:
-      interval: "weekly"
-    ignore:
-      - dependency-name: "Buildalyzer*"      
+      interval: "weekly"   


### PR DESCRIPTION
## Description
* Set dependabot to check for package updates on a weekly basis (checks on Monday by default)

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
