### PR TITLE
Add option to retain application DLLs when building a core application

### DIFF
--- a/src/Analysis/Codelyzer.Analysis.Build/WorkspaceBuilderHelper.cs
+++ b/src/Analysis/Codelyzer.Analysis.Build/WorkspaceBuilderHelper.cs
@@ -573,6 +573,10 @@ namespace Codelyzer.Analysis.Build
                 options.GlobalProperties.Add(MsBuildProperties.UseCommonOutputDirectory, "false");
                 options.GlobalProperties.Add(MsBuildProperties.SkipCopyBuildProduct, "false");
                 options.GlobalProperties.Add(MsBuildProperties.SkipCompilerExecution, "false");
+                if (!requiresNetFramework)
+                {
+                    options.GlobalProperties.Add(MsBuildProperties.BuildProjectReferences, "true");
+                }
             }
             return options;
         }


### PR DESCRIPTION
Add option to retain application DLLs when building a core application