### PR TITLE
fix: Update Buildalyzer to 4.1.3 which ensures distinct project reference

### DIFF
--- a/src/Analysis/Codelyzer.Analysis.Build/Codelyzer.Analysis.Build.csproj
+++ b/src/Analysis/Codelyzer.Analysis.Build/Codelyzer.Analysis.Build.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Buildalyzer" Version="3.2.8" />
-      <PackageReference Include="Buildalyzer.Logger" Version="3.2.8" />
-      <PackageReference Include="Buildalyzer.Workspaces" Version="3.2.8" />
+      <PackageReference Include="Buildalyzer" Version="4.1.3" />
+      <PackageReference Include="Buildalyzer.Logger" Version="4.1.3" />
+      <PackageReference Include="Buildalyzer.Workspaces" Version="4.1.3" />
       <PackageReference Include="NuGet.Packaging" Version="6.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     </ItemGroup>

--- a/src/Analysis/Codelyzer.Analysis.Model/Codelyzer.Analysis.Model.csproj
+++ b/src/Analysis/Codelyzer.Analysis.Model/Codelyzer.Analysis.Model.csproj
@@ -8,9 +8,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.CodeAnalysis" Version="4.1.0" />
-      <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.1.0" />
       <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
-      <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.1.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     </ItemGroup>

--- a/src/Analysis/Codelyzer.Analysis.Model/Codelyzer.Analysis.Model.csproj
+++ b/src/Analysis/Codelyzer.Analysis.Model/Codelyzer.Analysis.Model.csproj
@@ -7,8 +7,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.CodeAnalysis" Version="4.0.1" />
-      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
+      <PackageReference Include="Microsoft.CodeAnalysis" Version="4.1.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.1.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.1.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     </ItemGroup>


### PR DESCRIPTION
## Related issue: Customer couldn't port some projects because of duplicate project references in csproj files

Closes: #ISSUE_NUMBER_HERE

## Description
* The issue was caused by Buildalyzer didn't support distinct project references, which ends up Duplicate item exception in Roslyn. For more detail please refer to https://github.com/daveaglick/Buildalyzer/issues/203. The fix happened in Buildalyzer and this is to upgrade to latest Buildalyzer so Codelyzer could port csproj files even with duplicated project references. Latest Buildalyzer requires latest Microsoft.CodeAnalysis, so need to update that as well.

## Supplemental testing
The testing was done in Buildalyzer, for more detail please refer to PR at https://github.com/daveaglick/Buildalyzer/pull/204

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
