### PR TITLE
Added CastExpressionSyntax into identifier types

### DIFF
--- a/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/IdentifierNameHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/IdentifierNameHandler.cs
@@ -20,6 +20,7 @@ namespace Codelyzer.Analysis.CSharp.Handlers
             typeof(TypeArgumentListSyntax),
             typeof(ObjectCreationExpressionSyntax),
             typeof(QualifiedNameSyntax),
+            typeof(CastExpressionSyntax),
         };
 
         private DeclarationNode Model { get => (DeclarationNode)UstNode; }


### PR DESCRIPTION
## Related issue
CastExpressionSyntax was missing to deal with code analysis.

Closes: #ISSUE_NUMBER_HERE


## Description
* Added CastExpressionSyntax to include it during code analysis.

## Supplemental testing
Describe any testing done in addition to existing unit tests

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
