### PR TITLE
fix: sequence contains no elements errors

### DIFF
--- a/src/Analysis/Codelyzer.Analysis.Build/WorkspaceBuilderHelper.cs
+++ b/src/Analysis/Codelyzer.Analysis.Build/WorkspaceBuilderHelper.cs
@@ -358,6 +358,11 @@ namespace Codelyzer.Analysis.Build
          * */
         private void BuildSolution(IAnalyzerManager manager)
         {
+            if (manager.Projects.Count <= 0)
+            {
+                Logger.LogError($"Solution {manager.SolutionFilePath} does not have any projects");
+                return;
+            }
             var isSupportedProject = TryGetRequiresNetFramework(manager.Projects.First().Value.ProjectFile, out var isFramework);            
 
             //If we are building only, we don't need to run through the rest of the logic

--- a/tst/Codelyzer.Analysis.Tests/AnalyzerRefacTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/AnalyzerRefacTests.cs
@@ -1946,6 +1946,40 @@ End Namespace");
             Assert.IsNotNull(sdkreferences);
         }
 
+        [Test]
+        public async Task TestAnalyzeSolutionNoProjects()
+        {
+            AnalyzerCLI cli = new AnalyzerCLI();
+            cli.Configuration = new AnalyzerConfiguration(LanguageOptions.CSharp)
+            {
+                ExportSettings =
+                {
+                    GenerateJsonOutput = false,
+                    OutputPath = @"/tmp/UnitTests"
+                },
+
+                MetaDataSettings =
+                {
+                    LiteralExpressions = true,
+                    MethodInvocations = true,
+                    Annotations = true,
+                    LambdaMethods = true,
+                    DeclarationNodes = true,
+                    LocationData = true,
+                    ReferenceData = true,
+                    LoadBuildData = true,
+                    ReturnStatements = true,
+                    InterfaceDeclarations = true
+                }
+            };
+            string solutionPath = CopySolutionFolderToTemp("SolutionNoprojects.sln");
+            CodeAnalyzerByLanguage analyzerByLanguage = new CodeAnalyzerByLanguage(cli.Configuration, NullLogger.Instance);
+            var results = await analyzerByLanguage.AnalyzeSolution(solutionPath);
+            // results should return not null with no exceptions thrown, but with 0 results because no projects
+            Assert.IsNotNull(results);
+            Assert.IsTrue(results.Count == 0);
+        }
+
 
         #region private methods
         private void DeleteDir(string path, int retries = 0)


### PR DESCRIPTION
check if solution has projects before trying to build

## Description
Log error if manager doesn't have any project for a solution to monitor. Could be the solution has no projects or there is an issue with buildalyzer parsing projects into the manager. 

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
