### PR TITLE
fix: missing as clause identifiers

### DIFF
--- a/src/Analysis/Codelyzer.Analysis.VisualBasic/Handlers/IdentifierNameHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.VisualBasic/Handlers/IdentifierNameHandler.cs
@@ -20,6 +20,7 @@ namespace Codelyzer.Analysis.VisualBasic.Handlers
             typeof(TypeArgumentListSyntax),
             typeof(ObjectCreationExpressionSyntax),
             typeof(QualifiedNameSyntax),
+            typeof(SimpleAsClauseSyntax)
         };
 
         private DeclarationNode Model { get => (DeclarationNode)UstNode; }

--- a/tst/Codelyzer.Analysis.Tests/AnalyzerRefacTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/AnalyzerRefacTests.cs
@@ -631,7 +631,7 @@ namespace Codelyzer.Analysis.Tests
             var elementAccess = helpNamespaceBlock.AllElementAccessExpressions();
             var memberAccess = helpNamespaceBlock.AllMemberAccessExpressions();
 
-            Assert.AreEqual(4, declarationNodes.Count());
+            Assert.AreEqual(5, declarationNodes.Count());
 
             Assert.AreEqual(1, methodBlocks.Count());
 

--- a/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using Assert = NUnit.Framework.Assert;
 
 namespace Codelyzer.Analysis.Tests
@@ -1053,6 +1054,13 @@ namespace Mvc3ToolsUpdateWeb_Default.Controllers
 
             // imports found
             Assert.IsTrue(testClassRootNode.Children.OfType<ImportsStatement>().Select(i => i.Identifier).Contains("System"));
+
+            // as clause identifier is found
+            Assert.AreEqual(2,
+                testClassRootNode.AllDeclarationNodes()
+                    .Count(c =>
+                        c.Identifier == "Class2" &&
+                        c.Parent.GetType() == typeof(SimpleAsClause)));
         }
         [Test]
         public async Task TestNopCommerce()

--- a/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using Assert = NUnit.Framework.Assert;
 
 namespace Codelyzer.Analysis.Tests

--- a/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/AnalyzerTests.cs
@@ -653,7 +653,7 @@ namespace Codelyzer.Analysis.Tests
             var memberAccess = helpNamespaceBlock.AllMemberAccessExpressions();
 
             //HouseController has 3 identifiers declared within the class declaration:
-            Assert.AreEqual(4, declarationNodes.Count());
+            Assert.AreEqual(5, declarationNodes.Count());
 
             //It has 2 method declarations
             Assert.AreEqual(1, methodBlocks.Count());


### PR DESCRIPTION
## Description
* Parse handle identifier name nodes that are part of As Clause. This targets both parameters and return values.

## Supplemental testing
Add check in VBTestAnalysis to check for As Clause identifier nodes being returned.

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
