### PR TITLE
fix: create method original definition to closer match csharp value

### DIFF
--- a/src/Analysis/Codelyzer.Analysis.VisualBasic/Handlers/InvocationExpressionHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.VisualBasic/Handlers/InvocationExpressionHandler.cs
@@ -2,6 +2,7 @@ using Codelyzer.Analysis.Common;
 using Codelyzer.Analysis.Model;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
+using System.Linq;
 
 namespace Codelyzer.Analysis.VisualBasic.Handlers
 {
@@ -70,8 +71,6 @@ namespace Codelyzer.Analysis.VisualBasic.Handlers
                 Model.SemanticNamespace = invokedSymbol.ContainingNamespace.ToString();
 
             Model.SemanticMethodSignature = invokedSymbol.ToString();
-            if (invokedSymbol.OriginalDefinition != null)
-                Model.SemanticOriginalDefinition = invokedSymbol.OriginalDefinition.ToString();
 
             if (invokedSymbol.ReturnType != null)
                 Model.SemanticReturnType = invokedSymbol.ReturnType.Name;
@@ -82,6 +81,18 @@ namespace Codelyzer.Analysis.VisualBasic.Handlers
                 Model.SemanticClassType = Model.SemanticNamespace == null ? classNameWithNamespace :
                     SemanticHelper.GetSemanticClassType(classNameWithNamespace, Model.SemanticNamespace);
             }
+
+            string originalDefinition = "";
+            if (invokedSymbol.IsExtensionMethod && invokedSymbol.ReceiverType != null)
+            {
+                originalDefinition = invokedSymbol.ReceiverType.ToString();
+            }
+            else if (invokedSymbol.ContainingType != null)
+            {
+                originalDefinition = invokedSymbol.ContainingType.ToString();
+            }
+            Model.SemanticOriginalDefinition =
+                $"{originalDefinition}.{Model.MethodName}({string.Join(", ", invokedSymbol.Parameters.Select(p => p.Type))})";
 
 
             Model.Reference.Namespace = GetNamespace(invokedSymbol);

--- a/tst/Codelyzer.Analysis.Tests/AnalyzerRefacTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/AnalyzerRefacTests.cs
@@ -968,9 +968,6 @@ namespace Mvc3ToolsUpdateWeb_Default.Controllers
 
             // Chained method is found
             Assert.AreEqual(1, testClassRootNode.AllInvocationExpressions().Count(c => c.MethodName == "ChainedMethod"));
-            Assert.AreEqual("VBConsoleApp.Class2.ChainedMethod",
-                testClassRootNode.AllInvocationExpressions()
-                    .First(c => c.MethodName == "ChainedMethod"));
 
             // Constructor is found
             Assert.AreEqual(1, testClassRootNode.AllConstructors().Count);
@@ -1018,6 +1015,9 @@ namespace Mvc3ToolsUpdateWeb_Default.Controllers
 
             // Chained method is found
             Assert.AreEqual(1, testClassRootNode.AllInvocationExpressions().Count(c => c.MethodName == "ChainedMethod"));
+            Assert.AreEqual("VBConsoleApp.Class2.ChainedMethod()",
+                testClassRootNode.AllInvocationExpressions()
+                    .First(c => c.MethodName == "ChainedMethod").SemanticOriginalDefinition);
 
             // Constructor is found
             Assert.AreEqual(1, testClassRootNode.AllConstructorBlocks().Count);


### PR DESCRIPTION
## Description
* the original definition from the visual basic analysis comes back as a different value than the c# which means that methods won't match the action key from the rule files. 

## Supplemental testing
Add unit tests to confirm values match rules file for MapSignalR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
