### PR TITLE
fix: build errors for vb

### DIFF
--- a/src/Analysis/Codelyzer.Analysis.Build/ProjectBuildHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.Build/ProjectBuildHandler.cs
@@ -122,6 +122,17 @@ namespace Codelyzer.Analysis.Build
             return null;
         }
 
+        private bool CanSkipErrorsForVisualBasic()
+        {
+            // Compilation returns false build errors, it seems like we can work around this with
+            // MSBuildWorkspace instead of using an AdhocWorkspace
+            return Compilation != null &&
+                   Compilation.Language == "Visual Basic" &&
+                   AnalyzerResult.Succeeded &&
+                   Compilation.SyntaxTrees.Any() &&
+                   Compilation.GetSemanticModel(Compilation.SyntaxTrees.First()) != null;
+        }
+
         private async Task SetCompilation()
         {
             PrePortCompilation = await SetPrePortCompilation();         
@@ -129,7 +140,7 @@ namespace Codelyzer.Analysis.Build
             
             var errors = Compilation.GetDiagnostics()
                 .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
-            if (errors.Any())
+            if (errors.Any() && !CanSkipErrorsForVisualBasic())
             {
                 Logger.LogError($"Build Errors: {Compilation.AssemblyName}: {errors.Count()} " +
                                 $"compilation errors: \n\t{string.Join("\n\t", errors.Where(e => false).Select(e => e.ToString()))}");


### PR DESCRIPTION
## Description
There's an issue with the Compilation object returning error diagnostics when the solution/project can be compiled. Xuening did some research and this might be able to be resolved using the MsBuildWorkspace, but will investigate after the initial release. So for now just skip over reporting build errors if we are assessing a visual basic project, buildalyzer returns successful, and we are able to get syntax tree and semantic model.

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
