### PR TITLE
fix: possible null reference exception

### DIFF
--- a/src/Analysis/Codelyzer.Analysis.VisualBasic/Handlers/InvocationExpressionHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.VisualBasic/Handlers/InvocationExpressionHandler.cs
@@ -30,7 +30,7 @@ namespace Codelyzer.Analysis.VisualBasic.Handlers
                 //Object or Class invocations
                 var mae = ((MemberAccessExpressionSyntax)syntaxNode.Expression);
                 Model.MethodName = mae.Name.ToString();
-                Model.CallerIdentifier = mae.Expression.ToString();
+                Model.CallerIdentifier = mae.Expression?.ToString() ?? "";
             }
             else
             {

--- a/tst/Codelyzer.Analysis.Languages.UnitTests/VisualBasicHandlerTests.cs
+++ b/tst/Codelyzer.Analysis.Languages.UnitTests/VisualBasicHandlerTests.cs
@@ -130,7 +130,24 @@ namespace Codelyzer.Analysis.Languages.UnitTests
 			var endBlockNode = classBlockNode.Children[2];
 			Assert.True(endBlockNode.GetType() == typeof(Model.EndBlockStatement));
 			Assert.Equal("End Class", endBlockNode.Identifier);
-		}
+
+
+            var codeText = @"
+			Class TypeName
+				Public Sub Test()
+					Dim a = ""test""
+					String.Equals(a, ""v"", System.StringComparison.Ordinal)
+                    .StrangeMethod()
+				End Sub
+			End Class";
+            rootNode = GetVisualBasicUstNode(codeText);
+            Assert.Single(rootNode.Children);
+            classBlockNode = rootNode.Children[0];
+            Assert.Equal(3, classBlockNode.Children.Count);
+            var allInvocationExpressions = classBlockNode.AllInvocationExpressions();
+			Assert.Equal(2, allInvocationExpressions.Count);
+            Assert.Equal("", allInvocationExpressions.First(e => e.MethodName == "StrangeMethod").CallerIdentifier);
+        }
 
 
 		[Fact]


### PR DESCRIPTION
## Description
In vb, using a method like .MethodName() with nothing in front of the dot operator is valid syntax and Expression will be null in that case, so add a null check and set  caller identifier as blank if that's the case.

## Supplemental testing
Add unit test to handle weird syntax case

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
