### PR TITLE
Include identifiers that are part of a property

### DIFF
--- a/src/Analysis/Codelyzer.Analysis.Build/WorkspaceBuilder.cs
+++ b/src/Analysis/Codelyzer.Analysis.Build/WorkspaceBuilder.cs
@@ -1,6 +1,7 @@
 using Codelyzer.Analysis.Common;
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Logging;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -68,7 +69,7 @@ namespace Codelyzer.Analysis.Build
                             Dictionary<string, MetadataReference> references = new Dictionary<string, MetadataReference>();
 
                             var projectPath = result.ProjectAnalyzer.ProjectFile.Path;
-                            var project = builder.Projects.Find(p => p.ProjectAnalyzer.ProjectFile.Path.Equals(projectPath));
+                            var project = builder.Projects.Find(p => p.ProjectAnalyzer.ProjectFile.Path.Equals(projectPath, StringComparison.InvariantCultureIgnoreCase));
                             var projectReferencePaths = projectReferencesMap[projectPath]?.Distinct().ToHashSet<string>();
 
                             using (ProjectBuildHandler projectBuildHandler =
@@ -135,7 +136,7 @@ namespace Codelyzer.Analysis.Build
                     while (projectsInOrder.Count > 0)
                     {
                         var projectPath = projectsInOrder.Dequeue();
-                        var project = builder.Projects.Find(p => p.ProjectAnalyzer.ProjectFile.Path.Equals(projectPath));
+                        var project = builder.Projects.Find(p => p.ProjectAnalyzer.ProjectFile.Path.Equals(projectPath, StringComparison.InvariantCultureIgnoreCase));
                         var projectReferencePaths = projectReferencesMap[projectPath]?.Distinct().ToHashSet<string>();
 
                         using (ProjectBuildHandler projectBuildHandler =

--- a/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/IdentifierNameHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.CSharp/Handlers/IdentifierNameHandler.cs
@@ -21,6 +21,7 @@ namespace Codelyzer.Analysis.CSharp.Handlers
             typeof(ObjectCreationExpressionSyntax),
             typeof(QualifiedNameSyntax),
             typeof(CastExpressionSyntax),
+            typeof(PropertyDeclarationSyntax),
         };
 
         private DeclarationNode Model { get => (DeclarationNode)UstNode; }

--- a/src/Analysis/Codelyzer.Analysis/CodeGraph.cs
+++ b/src/Analysis/Codelyzer.Analysis/CodeGraph.cs
@@ -150,7 +150,7 @@ namespace Codelyzer.Analysis
                 try
                 {
                     var projectReferences = projectResult?.ExternalReferences?.ProjectReferences;
-                    var sourceNode = ProjectNodes.FirstOrDefault(p => p.Identifier == projectResult.ProjectFilePath);
+                    var sourceNode = ProjectNodes.FirstOrDefault(p => p.Identifier.Equals(projectResult.ProjectFilePath, StringComparison.InvariantCultureIgnoreCase));
 
                     projectReferences?.ForEach(projectReference =>
                     {

--- a/tst/Codelyzer.Analysis.Tests/AnalyzerRefacTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/AnalyzerRefacTests.cs
@@ -1612,7 +1612,7 @@ namespace Mvc3ToolsUpdateWeb_Default.Controllers
             Assert.AreEqual(0, nodes.FirstOrDefault(c => c.Identifier.Equals("Modernize.Web.Common.Constants")).AllOutgoingEdges.Count);
             Assert.AreEqual(0, nodes.FirstOrDefault(c => c.Identifier.Equals("Modernize.Web.Models.Customer")).AllOutgoingEdges.Count);
             Assert.AreEqual(0, nodes.FirstOrDefault(c => c.Identifier.Equals("Modernize.Web.Models.Product")).AllOutgoingEdges.Count);
-            Assert.AreEqual(0, nodes.FirstOrDefault(c => c.Identifier.Equals("Modernize.Web.Models.Purchase")).AllOutgoingEdges.Count);
+            Assert.AreEqual(2, nodes.FirstOrDefault(c => c.Identifier.Equals("Modernize.Web.Models.Purchase")).AllOutgoingEdges.Count);
             Assert.AreEqual(2, nodes.FirstOrDefault(c => c.Identifier.Equals("Modernize.Web.Models.Generics.ChildClass<ObjectType>")).AllOutgoingEdges.Count);
             Assert.AreEqual(0, nodes.FirstOrDefault(c => c.Identifier.Equals("Modernize.Web.Models.Generics.ParentClass<T>")).AllOutgoingEdges.Count);
             Assert.AreEqual(1, nodes.FirstOrDefault(c => c.Identifier.Equals("Modernize.Web.Models.Generics.ObjectType")).AllOutgoingEdges.Count);


### PR DESCRIPTION
Include identifiers that are part of a property when creating an analysis. This fixes an issue where identifiers that are part of a property in a class are not included in the analyzer results.