### PR TITLE
Performance optimization for AnalyzeSolutionGenerator

### DIFF
--- a/src/Analysis/Codelyzer.Analysis/Analyzer/CodeAnalyzerByLanguage.cs
+++ b/src/Analysis/Codelyzer.Analysis/Analyzer/CodeAnalyzerByLanguage.cs
@@ -36,6 +36,7 @@ namespace Codelyzer.Analysis.Analyzer
         public async Task<List<AnalyzerResult>> AnalyzeSolutionGenerator(string solutionPath)
         {
             var analyzerResults = await AnalyzeSolutionGeneratorAsync(solutionPath).ToListAsync();
+
             await GenerateOptionalOutput(analyzerResults);
             return analyzerResults;
         }
@@ -65,22 +66,16 @@ namespace Codelyzer.Analysis.Analyzer
                 throw new FileNotFoundException(path);
             }
 
-            List<ProjectWorkspace> workspaceResults = new List<ProjectWorkspace>();
-
             WorkspaceBuilder builder = new WorkspaceBuilder(Logger, path, AnalyzerConfiguration);
-
-
             var projectBuildResultEnumerator = builder.BuildProject().GetAsyncEnumerator();
             try
             {
-
                 while (await projectBuildResultEnumerator.MoveNextAsync().ConfigureAwait(false))
                 {
                     var projectBuildResult = projectBuildResultEnumerator.Current;
                     var workspaceResult = AnalyzeProject(projectBuildResult);
                     workspaceResult.ProjectGuid = projectBuildResult.ProjectGuid;
                     workspaceResult.ProjectType = projectBuildResult.ProjectType;
-                    workspaceResults.Add(workspaceResult);
 
                     if (AnalyzerConfiguration.MetaDataSettings.LoadBuildData)
                     {
@@ -156,7 +151,7 @@ namespace Codelyzer.Analysis.Analyzer
         public ProjectWorkspace AnalyzeProject(ProjectBuildResult projectResult)
         {
             Logger.LogDebug("Analyzing the project: " + projectResult.ProjectPath);
-            var projType = Path.GetExtension(projectResult.ProjectPath).ToLower();
+            var projType = Path.GetExtension(projectResult.ProjectPath)?.ToLower();
             LanguageAnalyzer languageAnalyzer = GetLanguageAnalyzerByProjectType(projType);
             ProjectWorkspace workspace = new ProjectWorkspace(projectResult.ProjectPath)
             {
@@ -197,7 +192,7 @@ namespace Codelyzer.Analysis.Analyzer
                     throw new Exception($"invalid project type {projType}");
             }
             return languageAnalyzerFactory.GetLanguageAnalyzer();
-            
+
         }
 
         public LanguageAnalyzer GetLanguageAnalyzerByFileType(string fileType)


### PR DESCRIPTION
## Description
* WorkspaceBuilderHelper.BuildIncremental - if a project reference was already built and added to a workspace, use the existing ProjectAnalysisResult instead of building again.

## Supplemental testing

### BenchmarkDotNet results for CodeAnalyzerByLanguage.AnalyzeSolutionGenerator method execution
``` ini

BenchmarkDotNet=v0.13.2, OS=Windows 10 (10.0.20348.887)
Intel Xeon Platinum 8375C CPU 2.90GHz, 1 CPU, 8 logical and 4 physical cores
.NET SDK=6.0.400
  [Host]     : .NET 6.0.8 (6.0.822.36306), X64 RyuJIT AVX2
  Job-WHKMPK : .NET 6.0.8 (6.0.822.36306), X64 RyuJIT AVX2

LaunchCount=1  RunStrategy=Monitoring  

```
|                   Method |     Mean |   Error |  StdDev | Ratio | RatioSD |        Gen0 |       Gen1 |      Gen2 | Allocated | Alloc Ratio |
|------------------------- |---------:|--------:|--------:|------:|--------:|------------:|-----------:|----------:|----------:|------------:|
| AnalyzeSolutionGenerator (Before changes) | 141.83 s | 3.001 s | 1.985 s |  3.55 |    0.05 | 202000.0000 | 89000.0000 | 1000.0000 |   5.73 GB |        1.17 |
| AnalyzeSolutionGenerator (After changes) | 62.38 s | 0.619 s | 0.409 s |  1.59 |    0.02 | 169000.0000 | 77000.0000 | 1000.0000 |   4.85 GB |        0.99 |

## Additional context
### Benchmarking code (in my fork; not in this PR) - 
1.  [Before changes](https://github.com/neerajhanda/codelyzer/tree/benchmark-main/tst/Codelyzer.Analysis.Benchmarks)
2. [After changes](https://github.com/neerajhanda/codelyzer/tree/benchmark-performance-enhancements/tst/Codelyzer.Analysis.Benchmarks)

### Unit tests - 
10 unit tests were failing on the main branch before my changes. No additional tests are failing after my changes.

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
