### PR TITLE
fix: null reference exceptions for specific vb syntax

### DIFF
--- a/src/Analysis/Codelyzer.Analysis.VisualBasic/Handlers/ArgumentListHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.VisualBasic/Handlers/ArgumentListHandler.cs
@@ -23,23 +23,28 @@ namespace Codelyzer.Analysis.VisualBasic.Handlers
             {
                 foreach (var argumentSyntax in syntaxNode.Arguments)
                 {
-                    Parameter parameter = new Parameter();
-                    if (argumentSyntax.GetExpression() != null)
-                        parameter.Name = argumentSyntax.GetExpression().ToString();
+                    var identifier = "";
+                    var semanticType = "";
 
-                    parameter.SemanticType =
-                        SemanticHelper.GetSemanticType(argumentSyntax.GetExpression(), SemanticModel, OriginalSemanticModel);
-#pragma warning disable CS0618 // Type or member is obsolete
-                    if (Model.Parameters != null)
+                    if (argumentSyntax is not OmittedArgumentSyntax)
                     {
-                        Model.Parameters.Add(parameter);
+                        identifier = argumentSyntax.GetExpression().ToString();
+                        semanticType = SemanticHelper.GetSemanticType(argumentSyntax.GetExpression(), SemanticModel);
                     }
+
+                    var parameter = new Parameter()
+                    {
+                        Name = identifier,
+                        SemanticType = semanticType
+                    };
+#pragma warning disable CS0618 // Type or member is obsolete
+                    Model.Parameters.Add(parameter);
 #pragma warning restore CS0618 // Type or member is obsolete
 
                     var argument = new Argument
                     {
-                        Identifier = argumentSyntax.GetExpression().ToString(),
-                        SemanticType = SemanticHelper.GetSemanticType(argumentSyntax.GetExpression(), SemanticModel, OriginalSemanticModel)
+                        Identifier = identifier,
+                        SemanticType = semanticType
                     };
                     Model.Arguments.Add(argument);
                 }

--- a/src/Analysis/Codelyzer.Analysis.VisualBasic/Handlers/ConstructorBlockHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.VisualBasic/Handlers/ConstructorBlockHandler.cs
@@ -19,18 +19,21 @@ namespace Codelyzer.Analysis.VisualBasic.Handlers
 
         private void SetMetaData(ConstructorBlockSyntax syntaxNode)
         {
-            foreach (var parameter in syntaxNode.SubNewStatement.ParameterList.Parameters)
+            if (syntaxNode.SubNewStatement.ParameterList != null)
             {
-                var param = new Parameter
+                foreach (var parameter in syntaxNode.SubNewStatement.ParameterList.Parameters)
                 {
-                    Name = parameter.Identifier.ToString()
-                };
-                
-                if (parameter.AsClause.Type != null)
-                    param.Type = parameter.AsClause.Type.ToString();
+                    var param = new Parameter
+                    {
+                        Name = parameter.Identifier.ToString()
+                    };
+                    
+                    if (parameter.AsClause.Type != null)
+                        param.Type = parameter.AsClause.Type.ToString();
 
-                param.SemanticType = SemanticHelper.GetSemanticType(parameter.AsClause.Type, SemanticModel, OriginalSemanticModel);
-                Model.Parameters.Add(param);
+                    param.SemanticType = SemanticHelper.GetSemanticType(parameter.AsClause.Type, SemanticModel, OriginalSemanticModel);
+                    Model.Parameters.Add(param);
+                }
             }
 
             Model.Modifiers = syntaxNode.SubNewStatement.Modifiers.ToString();

--- a/src/Analysis/Codelyzer.Analysis.VisualBasic/Handlers/InvocationExpressionHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.VisualBasic/Handlers/InvocationExpressionHandler.cs
@@ -39,26 +39,35 @@ namespace Codelyzer.Analysis.VisualBasic.Handlers
                     Model.MethodName = syntaxNode.Expression.ToString();
             }
 
-            foreach (var argumentSyntax in syntaxNode.ArgumentList.Arguments)
+            if (syntaxNode.ArgumentList != null)
             {
-                Parameter parameter = new Parameter();
-                if (argumentSyntax.GetExpression() != null)
-                    parameter.Name = argumentSyntax.GetExpression().ToString();
-
-                parameter.SemanticType =
-                    SemanticHelper.GetSemanticType(argumentSyntax.GetExpression(), SemanticModel);
-
-#pragma warning disable CS0618 // Type or member is obsolete
-                Model.Parameters.Add(parameter);
-#pragma warning restore CS0618 // Type or member is obsolete
-
-                var argument = new Argument
+                foreach (var argumentSyntax in syntaxNode.ArgumentList.Arguments)
                 {
-                    Identifier = argumentSyntax.GetExpression().ToString(),
-                    SemanticType = SemanticHelper.GetSemanticType(argumentSyntax.GetExpression(), SemanticModel)
-                };
+                    var identifier = "";
+                    var semanticType = "";
 
-                Model.Arguments.Add(argument);
+                    if (argumentSyntax is not OmittedArgumentSyntax)
+                    {
+                        identifier = argumentSyntax.GetExpression().ToString();
+                        semanticType = SemanticHelper.GetSemanticType(argumentSyntax.GetExpression(), SemanticModel);
+                    }
+
+                    var parameter = new Parameter()
+                    {
+                        Name = identifier,
+                        SemanticType = semanticType
+                    };
+    #pragma warning disable CS0618 // Type or member is obsolete
+                    Model.Parameters.Add(parameter);
+    #pragma warning restore CS0618 // Type or member is obsolete
+
+                    var argument = new Argument
+                    {
+                        Identifier = identifier,
+                        SemanticType = semanticType
+                    };
+                    Model.Arguments.Add(argument);
+                }
             }
 
             if (SemanticModel == null) return;

--- a/src/Analysis/Codelyzer.Analysis.VisualBasic/Handlers/MethodStatementHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.VisualBasic/Handlers/MethodStatementHandler.cs
@@ -25,8 +25,12 @@ namespace Codelyzer.Analysis.VisualBasic.Handlers
                     if (parameter.AsClause?.Type != null)
                         param.Type = parameter.AsClause.Type.ToString();
 
-                    param.SemanticType =
-                        SemanticHelper.GetSemanticType(parameter.AsClause.Type, SemanticModel, OriginalSemanticModel);
+                    if (parameter.AsClause != null)
+                    {
+                        param.SemanticType =
+                            SemanticHelper.GetSemanticType(parameter.AsClause.Type, SemanticModel,
+                                OriginalSemanticModel);
+                    }
                     Model.Parameters.Add(param);
                 }
             }

--- a/tst/Codelyzer.Analysis.Languages.UnitTests/VisualBasicHandlerTests.cs
+++ b/tst/Codelyzer.Analysis.Languages.UnitTests/VisualBasicHandlerTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Xunit;
 using Microsoft.CodeAnalysis;
 using Codelyzer.Analysis.Common;
@@ -7,6 +8,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Codelyzer.Analysis.VisualBasic;
 using System.Linq;
 using Codelyzer.Analysis.Model;
+using Microsoft.Extensions.Logging;
 
 namespace Codelyzer.Analysis.Languages.UnitTests
 {
@@ -148,6 +150,51 @@ namespace Codelyzer.Analysis.Languages.UnitTests
 			Assert.Equal(2, allInvocationExpressions.Count);
             Assert.Equal("", allInvocationExpressions.First(e => e.MethodName == "StrangeMethod").CallerIdentifier);
         }
+
+		[Fact]
+		public void InvocationExpressionHandlerTestOmittedParamAndNoParams()
+		{
+			var expressShell = @"
+			Class TypeName
+				Public Sub New
+					MyBase.New	
+				End Sub
+
+				Public Sub Test()
+					TestFunction(""hello"", )
+				End Sub
+
+				Private Sub TestFunction (a as String, Optional b as Boolean)
+					If B
+						Console.WriteLine(""True"")
+					Else 
+						Console.WriteLine(""False"")
+					End If
+				End Sub
+			End Class";
+			var rootNode = GetVisualBasicUstNode(expressShell);
+			Assert.Single(rootNode.Children);
+			var classBlockNode = rootNode.Children[0];
+			Assert.Equal(5, classBlockNode.Children.Count);
+
+			//0:class-statement
+			var classStatementNode = classBlockNode.Children[0];
+			Assert.True(classStatementNode.GetType() == typeof(Model.ClassStatement));
+			//1:sub-block
+			var subBlockNode = classBlockNode.Children[3];
+			Assert.True(subBlockNode.GetType() == typeof(Model.MethodBlock));
+			Assert.Equal("SubBlock", subBlockNode.Identifier);
+			Assert.Equal(3, subBlockNode.Children.Count);
+
+			var invocationExpressions = classBlockNode.AllInvocationExpressions().ToList();
+			var myBaseNew = invocationExpressions.FirstOrDefault(e => e.Identifier == "MyBase.New");
+			var omitted = invocationExpressions.FirstOrDefault(e => e.MethodName == "TestFunction");
+			Assert.NotNull(myBaseNew);
+			Assert.NotNull(omitted);
+			Assert.Empty(myBaseNew.Arguments);
+			Assert.Equal(2, omitted.Arguments.Count);
+			Assert.Equal("", omitted.Arguments[1].SemanticType);
+		}
 
 
 		[Fact]
@@ -530,6 +577,25 @@ namespace Codelyzer.Analysis.Languages.UnitTests
 			Assert.Equal(typeof(Model.EndBlockStatement), endNode.GetType());
 
 
+		}
+
+		[Fact]
+		public void MethodStatementHandlerTest()
+		{
+			var expressShell = @"
+				Class TestClass
+					Public Sub sfLoad(ByVal pArgs())
+					End Sub
+				End Class";
+			var rootNode = GetVisualBasicUstNode(expressShell);
+
+			var classNode = rootNode.Children.FirstOrDefault();
+			Assert.NotNull(classNode);
+			var methodBlock = classNode.AllMethodBlocks().FirstOrDefault();
+			Assert.NotNull(methodBlock);
+			var methodStatement = (MethodStatement) methodBlock.Children.FirstOrDefault(c => c is MethodStatement);
+			Assert.NotNull(methodStatement);
+			Assert.Single(methodStatement.Parameters);
 		}
 
 		private Model.UstNode GetVisualBasicUstNode(string expressionShell)


### PR DESCRIPTION
## Description
Add some null checks to address null references that happen for specific vb syntax scenarios.

Public Sub sfLoad(ByVal pArgs()) - parameter doesn't have as clause in method statement handler.
MyBase.New - parameter list in InvocationExpression is null
DataAdapter.Fill(table, EntityMappings, , , True) - omitted arguments in method call with optional parameters

## Supplemental testing
Added unit tests to reproduce the exceptions and test fix.

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
