### PR TITLE
Fix bug for solutions with incompatible projects

### DIFF
--- a/src/Analysis/Codelyzer.Analysis.Build/ProjectBuildHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.Build/ProjectBuildHandler.cs
@@ -607,11 +607,17 @@ namespace Codelyzer.Analysis.Build
         {
             SetSyntaxCompilation(metadataReferences?.Values?.ToList());
 
+            if (Compilation == null)
+            {
+                Logger.LogError($"Error while building project {ProjectAnalyzer?.ProjectFile?.Path}");
+                return null;
+            }
+
             ProjectBuildResult projectBuildResult = new ProjectBuildResult
             {
                 BuildErrors = Errors,
                 ProjectPath = ProjectAnalyzer?.ProjectFile?.Path,
-                ProjectRootPath = Path.GetDirectoryName(ProjectAnalyzer.ProjectFile.Path),
+                ProjectRootPath = Path.GetDirectoryName(ProjectAnalyzer?.ProjectFile?.Path),
                 Compilation = Compilation,
                 IsSyntaxAnalysis = isSyntaxAnalysis,
                 ExternalReferences = new ExternalReferences()
@@ -629,7 +635,7 @@ namespace Codelyzer.Analysis.Build
                 projectBuildResult.ProjectGuid = ProjectAnalyzer.ProjectGuid.ToString();
                 projectBuildResult.ProjectType = ProjectAnalyzer.ProjectInSolution != null ? ProjectAnalyzer.ProjectInSolution.ProjectType.ToString() : string.Empty;
 
-                foreach (var syntaxTree in Compilation.SyntaxTrees)
+                foreach (var syntaxTree in Compilation?.SyntaxTrees)
                 {
                     var sourceFilePath = Path.GetRelativePath(projectBuildResult.ProjectRootPath, syntaxTree.FilePath);
                     var fileResult = new SourceFileBuildResult

--- a/src/Analysis/Codelyzer.Analysis.Build/WorkspaceBuilder.cs
+++ b/src/Analysis/Codelyzer.Analysis.Build/WorkspaceBuilder.cs
@@ -82,8 +82,11 @@ namespace Codelyzer.Analysis.Build
                                 projectBuildHandler.ProjectAnalyzer = project.ProjectAnalyzer;
                                 var projectReferences = references.Where(r => projectReferencePaths.Contains(r.Key)).ToDictionary(p => p.Key, p => p.Value);
                                 var result = projectBuildHandler.SyntaxOnlyBuild(projectReferences);
-                                references.Add(projectPath, result.Compilation.ToMetadataReference());
-                                yield return result;
+                                if (result != null)
+                                {
+                                    references.Add(projectPath, result.Compilation.ToMetadataReference());
+                                    yield return result;
+                                }
                             }
                         }
                     }
@@ -147,8 +150,11 @@ namespace Codelyzer.Analysis.Build
                             projectBuildHandler.ProjectAnalyzer = project.ProjectAnalyzer;
                             var projectReferences = references.Where(r => projectReferencePaths.Contains(r.Key)).ToDictionary(p=>p.Key, p=> p.Value);
                             var result = projectBuildHandler.SyntaxOnlyBuild(projectReferences);
-                            references.Add(projectPath, result.Compilation.ToMetadataReference());
-                            ProjectResults.Add(result);
+                            if (result != null)
+                            {
+                                references.Add(projectPath, result.Compilation.ToMetadataReference());
+                                ProjectResults.Add(result);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Related issue

If a solution has an incompatible project (e.g. C++ project) - the analysis fails and terminates. We need to continue assessment and not fail it in case this happens


## Description
Skip a project when unable to create a compilation

## Supplemental testing
Tested locally on solution with C++ project
---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
