### PR TITLE
Add build error compilation.

### DIFF
--- a/src/Analysis/Codelyzer.Analysis.Build/ProjectBuildHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.Build/ProjectBuildHandler.cs
@@ -154,7 +154,7 @@ namespace Codelyzer.Analysis.Build
             if (errors.Any() && !CanSkipErrorsForVisualBasic())
             {
                 Logger.LogError($"Build Errors: {Compilation.AssemblyName}: {errors.Count()} " +
-                                $"compilation errors: \n\t{string.Join("\n\t", errors.Where(e => false).Select(e => e.ToString()))}");
+                                $"compilation errors: \n\t{string.Join("\n\t", errors.Select(e => e.ToString()))}"); // Add telemetry for individual build errors
                 Logger.LogDebug(String.Join("\n", errors));
 
                 foreach (var error in errors)
@@ -443,7 +443,7 @@ namespace Codelyzer.Analysis.Build
             if (errors.Any())
             {
                 Logger.LogError($"Build Errors: {Compilation.AssemblyName}: {errors.Count()} " +
-                                $"compilation errors: \n\t{string.Join("\n\t", errors.Where(e => false).Select(e => e.ToString()))}");
+                                $"compilation errors: \n\t{string.Join("\n\t", errors.Select(e => e.ToString()))}"); // Add telemetry for individual build errors
                 Logger.LogDebug(String.Join("\n", errors));
 
                 foreach (var error in errors)


### PR DESCRIPTION
## Related issue

Closes: #ISSUE_NUMBER_HERE
https://sim.amazon.com/issues/P79785442


## Description
Add compilation for build errors, they are currently blank due to a bug.

## Supplemental testing
Tested locally with a solution.

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
