### PR TITLE
Updated MergeGraph function to MergeGraphs allowing for multiple graphs to merge, moved initialization of CodeGraph properties to constructor

### DIFF
--- a/src/Analysis/Codelyzer.Analysis/CodeGraph.cs
+++ b/src/Analysis/Codelyzer.Analysis/CodeGraph.cs
@@ -123,16 +123,16 @@ namespace Codelyzer.Analysis
         public CodeGraph(ILogger logger)
         {
             Logger = logger;
-        }         
-        public void Initialize(List<AnalyzerResult> analyzerResults)
-        {
             projectWorkspaces = new HashSet<ProjectWorkspace>();
             ustNodeEdgeCandidates = new Dictionary<Node, List<UstNode>>();
             filteredUstNodeEdgeCandidates = new Dictionary<Node, List<UstNode>>();
             Graph = new HashSet<Node>();
+        }         
+        public void Initialize(List<AnalyzerResult> analyzerResults)
+        {
             PopulateGraphs(analyzerResults);
         }
-        public void MergeGraph(CodeGraph targetGraph)
+        public void MergeGraphs(List<CodeGraph> codeGraphs)
         {
             //Clear previous variable to re-initiate:
             _projectNodes=null;
@@ -143,10 +143,23 @@ namespace Codelyzer.Analysis
             _enumNodes=null;
             _recordNodes=null;
             _methodNodes=null;
-            projectWorkspaces.AddRange(targetGraph.projectWorkspaces);
-            Graph.AddRange(targetGraph.Graph);
-            // Merge the edge candidates
-            ustNodeEdgeCandidates.AddRange(targetGraph.ustNodeEdgeCandidates);
+
+            foreach (CodeGraph codeGraph in codeGraphs)
+            {
+                projectWorkspaces.AddRange(codeGraph.projectWorkspaces);
+                Graph.AddRange(codeGraph.Graph);
+                foreach (var kvp in codeGraph.ustNodeEdgeCandidates)
+                {
+                    if (ustNodeEdgeCandidates.ContainsKey(kvp.Key))
+                    {
+                        ustNodeEdgeCandidates[kvp.Key].AddRange(kvp.Value);
+                    }
+                    else
+                    {
+                        ustNodeEdgeCandidates.Add(kvp.Key, kvp.Value);
+                    }
+                }
+            }
 
             // Remove edges that are external to the projects
             RemoveExternalEdges();

--- a/tst/Codelyzer.Analysis.Tests/AnalyzerRefacTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/AnalyzerRefacTests.cs
@@ -1701,10 +1701,7 @@ namespace Mvc3ToolsUpdateWeb_Default.Controllers
             });
 
             var originalGraph = allGraphs[0];
-            for(int i=1; i<allGraphs.Count; i++)
-            {
-                originalGraph.MergeGraph(allGraphs[i]);
-            }
+            originalGraph.MergeGraphs(allGraphs);
 
             var resultParallel = new SolutionAnalyzerResult()
             {


### PR DESCRIPTION
Updated MergeGraph function to MergeGraphs allowing for multiple graphs to merge, moved initialization of CodeGraph properties to constructor

## Related issue

Closes: N/A

## Description
* Moves initialization of CodeGraph properties to constructor
* Changed MergeGraph to MergeGraphs in order to allow for the merging of multiple CodeGraphs, inputted as a list

## Supplemental testing
`TestModernizeParallelizeGraph` updated for updated function

## Additional context
The move from MergeGraph to MergeGraphs allows us to call `RemoveExternalEdges` and `AddEdges` once at the end of the aggregate graph to make the process more performant.

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
