### PR TITLE
Added setters for ProjectWorkspace fields ProjectName and ProjectRootPath for deserialization

### DIFF
--- a/src/Analysis/Codelyzer.Analysis.Model/ProjectWorkspace.cs
+++ b/src/Analysis/Codelyzer.Analysis.Model/ProjectWorkspace.cs
@@ -14,10 +14,10 @@ namespace Codelyzer.Analysis.Model
         public string GeneratedBy { get; set; }
 
         [JsonProperty("workspace-name", Order = 3)]
-        public string ProjectName { get; }
+        public string ProjectName { get; set; }
         
         [JsonProperty("workspace-root-path", Order = 4)]
-        public string ProjectRootPath { get; }
+        public string ProjectRootPath { get; set; }
 
         [JsonProperty("source-files", Order = 5)]
         public UstList<string> SourceFiles;


### PR DESCRIPTION
## Description
* Required for complete deserialization of AnalyzerResult/ProjectWorkspace object

## Supplemental testing
Local testing

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
