### PR TITLE
Added .ToLower() for node identifiers to ensure proper CSV creation, updated Edge equality operator

### DIFF
--- a/src/Analysis/Codelyzer.Analysis/AbstractGraph.cs
+++ b/src/Analysis/Codelyzer.Analysis/AbstractGraph.cs
@@ -181,8 +181,8 @@ namespace Codelyzer.Analysis
                     projectWorkspaces.Add(new ProjectInfo()
                     {
                         Name = analyzerResult.ProjectResult.ProjectName,
-                        Identifier = analyzerResult.ProjectResult.ProjectFilePath,
-                        References = analyzerResult.ProjectResult.ExternalReferences.ProjectReferences.Select(r => r.AssemblyLocation).ToList()
+                        Identifier = analyzerResult.ProjectResult.ProjectFilePath.ToLower(),
+                        References = analyzerResult.ProjectResult.ExternalReferences.ProjectReferences.Select(r => r.AssemblyLocation.ToLower()).ToList()
                     });
 
                     // Add Relevant Children from source files
@@ -457,13 +457,15 @@ namespace Codelyzer.Analysis
                 return edge.Identifier == this.Identifier
                     && edge.EdgeType == this.EdgeType
                     && edge.SourceNode == this.SourceNode
-                    && edge.TargetNode == this.TargetNode;
+                    && edge.TargetNode == this.TargetNode
+                    && edge.SourceNodeId == this.SourceNodeId
+                    && edge.TargetNodeId == this.TargetNodeId;
             }
             return false;
         }
         public override int GetHashCode()
         {
-            return HashCode.Combine(Identifier, SourceNode, TargetNode, EdgeType);
+            return HashCode.Combine(Identifier, SourceNode, TargetNode, SourceNodeId, TargetNodeId, EdgeType);
         }
     }
 

--- a/src/Analysis/Codelyzer.Analysis/CompactGraph.cs
+++ b/src/Analysis/Codelyzer.Analysis/CompactGraph.cs
@@ -67,8 +67,8 @@ namespace Codelyzer.Analysis
                     {
                         ConcurrentEdges.Add(new Edge()
                         {
-                            SourceNodeId = projectResult.Identifier,
-                            TargetNodeId = projectReference,
+                            SourceNodeId = projectResult.Identifier.ToLower(),
+                            TargetNodeId = projectReference.ToLower(),
                             EdgeType = EdgeType.ProjectReference
                         });
                     });

--- a/tst/Codelyzer.Analysis.Tests/AnalyzerRefacTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/AnalyzerRefacTests.cs
@@ -1783,13 +1783,13 @@ namespace Mvc3ToolsUpdateWeb_Default.Controllers
             Assert.AreEqual(5, deserialized.Graph.Keys.Count(k => k.NodeType == NodeType.Project));
 
             //The Facade project has 3 Edges
-            Assert.AreEqual(3, deserialized.ConcurrentEdges.Count(e => e.SourceNodeId.EndsWith("Modernize.Web.Facade.csproj")));
+            Assert.AreEqual(3, deserialized.ConcurrentEdges.Count(e => e.SourceNodeId.EndsWith("modernize.web.facade.csproj")));
             
             // The Mvc project has 3 Edges
-            Assert.AreEqual(3, deserialized.ConcurrentEdges.Count(e => e.SourceNodeId.EndsWith("Modernize.Web.Mvc.csproj")));
+            Assert.AreEqual(3, deserialized.ConcurrentEdges.Count(e => e.SourceNodeId.EndsWith("modernize.web.mvc.csproj")));
 
             //// The Models project has 0 Edges
-            Assert.AreEqual(0, deserialized.ConcurrentEdges.Count(e => e.SourceNodeId.EndsWith("Modernize.Web.Models.csproj")));
+            Assert.AreEqual(0, deserialized.ConcurrentEdges.Count(e => e.SourceNodeId.EndsWith("modernize.web.models.csproj")));
 
             //// There are 27 classes in the solution
             Assert.AreEqual(27, deserialized.Graph.Keys.Count(n=>n.NodeType == NodeType.Class));


### PR DESCRIPTION
## Description
* In order to ensure proper generation of project edges, we needed to lowercase certain identifiers
* In order to ensure completely equality between edges (to assist in tasks such as deduping), we need to update the Equals method of Edge type

## Supplemental testing
Local testing

## Additional context
N/A

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
