### PR TITLE
Fix project references causing analysis of project to fail

### DIFF
--- a/src/Analysis/Codelyzer.Analysis.Build/WorkspaceBuilder.cs
+++ b/src/Analysis/Codelyzer.Analysis.Build/WorkspaceBuilder.cs
@@ -199,7 +199,7 @@ namespace Codelyzer.Analysis.Build
             }
             else
             {
-                Logger.LogDebug($"Missing project found in references {projectPath}");
+                Logger.LogInformation($"Missing project found in references {projectPath}");
             }
         }
 

--- a/src/Analysis/Codelyzer.Analysis.Build/WorkspaceBuilder.cs
+++ b/src/Analysis/Codelyzer.Analysis.Build/WorkspaceBuilder.cs
@@ -187,15 +187,20 @@ namespace Codelyzer.Analysis.Build
 
         private void CreateDependencyQueueHelper(string projectPath, HashSet<string> builtProjects, Dictionary<string, HashSet<string>> projectReferencesMap, Queue<string> buildOrder)
         {
-            builtProjects.Add(projectPath);
-
-            foreach (var dependency in projectReferencesMap[projectPath])
+            if (projectReferencesMap.ContainsKey(projectPath))
             {
-                if (!builtProjects.Contains(dependency))
-                    CreateDependencyQueueHelper(dependency, builtProjects, projectReferencesMap, buildOrder);
+                builtProjects.Add(projectPath);
+                foreach (var dependency in projectReferencesMap[projectPath])
+                {
+                    if (!builtProjects.Contains(dependency))
+                        CreateDependencyQueueHelper(dependency, builtProjects, projectReferencesMap, buildOrder);
+                }
+                buildOrder.Enqueue(projectPath);
             }
-
-            buildOrder.Enqueue(projectPath);
+            else
+            {
+                Logger.LogDebug($"Missing project found in references {projectPath}");
+            }
         }
 
         public List<ProjectBuildResult> GenerateNoBuildAnalysis(Dictionary<string, List<string>> oldReferences, Dictionary<string, List<string>> references)

--- a/src/Analysis/Codelyzer.Analysis.Model/ProjectWorkspace.cs
+++ b/src/Analysis/Codelyzer.Analysis.Model/ProjectWorkspace.cs
@@ -14,10 +14,10 @@ namespace Codelyzer.Analysis.Model
         public string GeneratedBy { get; set; }
 
         [JsonProperty("workspace-name", Order = 3)]
-        public string ProjectName { get; }
+        public string ProjectName { get; set; }
         
         [JsonProperty("workspace-root-path", Order = 4)]
-        public string ProjectRootPath { get; }
+        public string ProjectRootPath { get; set; }
 
         [JsonProperty("source-files", Order = 5)]
         public UstList<string> SourceFiles;


### PR DESCRIPTION
## Related issue

Addresses issue where analysis fails if project references have incorrect files


## Description
When a csproj file contains invalid project references (e.g. mistyped, removed, or moved projects) the project is excluded from analysis and is not shown in the visualization.

This issue addresses it by updating the reference finder logic to log the issue of a missing reference instead of terminating the analysis of the whole project.

## Supplemental testing
Manual testing, in addition to a new test added with the scenario described above.


---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
