### PR TITLE
Convert VB generic type definitions to original definitions using CSharp syntax

### DIFF
--- a/src/Analysis/Codelyzer.Analysis.Build/ProjectBuildHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.Build/ProjectBuildHandler.cs
@@ -255,7 +255,7 @@ namespace Codelyzer.Analysis.Build
             var extension = Path.GetExtension(projectPath);
             if (!string.IsNullOrEmpty(extension) && extension.Equals(".vbproj", StringComparison.InvariantCultureIgnoreCase))
             {
-                var allFiles = FileUtils.GetProjectCodeFiles(ProjectAnalyzer.ProjectFile.Path, directory.FullName, "*.vbproj", "*.vb");
+                var allFiles = FileUtils.GetProjectCodeFiles(projectPath, directory.FullName, "*.vbproj", "*.vb");
                 foreach (var file in allFiles)
                 {
                     try
@@ -280,7 +280,7 @@ namespace Codelyzer.Analysis.Build
             }
             else
             {
-                var allCSharpFiles = FileUtils.GetProjectCodeFiles(ProjectAnalyzer.ProjectFile.Path, directory.FullName, "*.csproj", "*.cs");
+                var allCSharpFiles = FileUtils.GetProjectCodeFiles(projectPath, directory.FullName, "*.csproj", "*.cs");
                 foreach (var file in allCSharpFiles)
                 {
                     try

--- a/src/Analysis/Codelyzer.Analysis.VisualBasic/Handlers/InvocationExpressionHandler.cs
+++ b/src/Analysis/Codelyzer.Analysis.VisualBasic/Handlers/InvocationExpressionHandler.cs
@@ -142,17 +142,24 @@ namespace Codelyzer.Analysis.VisualBasic.Handlers
                 return classNameWithNamespace;
             }
 
-            // Generic VB classes need to be converted to CSharp syntax
-            // Example: VB: System.Collections.Generic.Dictionary(Of String, String)
-            //          C#: System.Collections.Generic.Dictionary<TKey, TValue>
-            var typeParameters = typeSymbol.TypeParameters.Select(p => p.Name);
-            var cSharpParametersAsString = $"<{string.Join(", ", typeParameters)}>";
+            try
+            {
+                // Generic VB classes need to be converted to CSharp syntax
+                // Example: VB: System.Collections.Generic.Dictionary(Of String, String)
+                //          C#: System.Collections.Generic.Dictionary<TKey, TValue>
+                var typeParameters = typeSymbol.TypeParameters.Select(p => p.Name);
+                var cSharpParametersAsString = $"<{string.Join(", ", typeParameters)}>";
 
-            var vbTypeParamStartIndex = classNameWithNamespace.LastIndexOf("(", StringComparison.OrdinalIgnoreCase);
-            var vbTypeParamEndIndex = classNameWithNamespace.LastIndexOf(")", StringComparison.OrdinalIgnoreCase);
-            var vbTypeParametersAsString = classNameWithNamespace.Substring(vbTypeParamStartIndex, vbTypeParamEndIndex - vbTypeParamStartIndex + 1);
-
-            return classNameWithNamespace.Replace(vbTypeParametersAsString, cSharpParametersAsString);
+                var vbTypeParamStartIndex = classNameWithNamespace.LastIndexOf("(", StringComparison.OrdinalIgnoreCase);
+                var vbTypeParamEndIndex = classNameWithNamespace.LastIndexOf(")", StringComparison.OrdinalIgnoreCase);
+                var vbTypeParametersAsString = classNameWithNamespace.Substring(vbTypeParamStartIndex, vbTypeParamEndIndex - vbTypeParamStartIndex + 1);
+                return classNameWithNamespace.Replace(vbTypeParametersAsString, cSharpParametersAsString);
+            }
+            catch
+            {
+                // Return default value if a type is labeled as generic but does not have type parameters
+                return classNameWithNamespace;
+            }
         }
 
         void HandlePropertySymbol(IPropertySymbol invokedSymbol)

--- a/tst/Codelyzer.Analysis.Tests/InvocationExpressionHandlerTests.cs
+++ b/tst/Codelyzer.Analysis.Tests/InvocationExpressionHandlerTests.cs
@@ -1,0 +1,64 @@
+﻿using System.Collections.Immutable;
+using Codelyzer.Analysis.VisualBasic.Handlers;
+using Microsoft.CodeAnalysis;
+using NUnit.Framework;
+using Moq;
+
+namespace Codelyzer.Analysis.Tests
+{
+    public class InvocationExpressionHandlerTests
+    {
+        [Test]
+        public void TypeSymbolWithTypeParameters_Returns_TypeNameWithTypeParametersInCSharpSyntax()
+        {
+            var typeParameter1 = new Mock<ITypeParameterSymbol>();
+            typeParameter1.Setup(p => p.Name).Returns("tpName1");
+            var typeParameter2 = new Mock<ITypeParameterSymbol>();
+            typeParameter2.Setup(p => p.Name).Returns("tpName2");
+            var typeParameters = ImmutableArray.Create(typeParameter1.Object, typeParameter2.Object);
+
+            var typeSymbolWithTypeParameters = new Mock<INamedTypeSymbol>();
+            typeSymbolWithTypeParameters.Setup(s => s.ToString()).Returns("typeSymbolStringForm(xyz)");
+            typeSymbolWithTypeParameters.Setup(s => s.IsGenericType).Returns(true);
+            typeSymbolWithTypeParameters.Setup(s => s.TypeParameters).Returns(typeParameters);
+
+            var getClassNameWithNamespace = TestUtils.GetPrivateStaticMethod(typeof(InvocationExpressionHandler), "GetClassNameWithNamespace");
+            var typeNameWithTypeParametersInCSharpSyntax = getClassNameWithNamespace.Invoke(null, new object[] { typeSymbolWithTypeParameters.Object });
+
+            Assert.AreEqual("typeSymbolStringForm<tpName1, tpName2>", typeNameWithTypeParametersInCSharpSyntax);
+        }
+
+        [Test]
+        public void TypeSymbolWithoutTypeParameters_Returns_TypeNameInStringForm()
+        {
+            var typeSymbolWithoutTypeParameters = new Mock<INamedTypeSymbol>();
+            typeSymbolWithoutTypeParameters.Setup(s => s.ToString()).Returns("typeSymbolStringForm");
+
+            var getClassNameWithNamespace = TestUtils.GetPrivateStaticMethod(typeof(InvocationExpressionHandler), "GetClassNameWithNamespace");
+            var typeNameInStringForm = getClassNameWithNamespace.Invoke(null, new object[] { typeSymbolWithoutTypeParameters.Object });
+
+            Assert.AreEqual("typeSymbolStringForm", typeNameInStringForm);
+        }
+
+        [Test]
+        public void NonGenericTypeSymbol_Returns_TypeNameInStringForm()
+        {
+            var typeParameter1 = new Mock<ITypeParameterSymbol>();
+            typeParameter1.Setup(p => p.Name).Returns("tpName1");
+            var typeParameter2 = new Mock<ITypeParameterSymbol>();
+            typeParameter2.Setup(p => p.Name).Returns("tpName2");
+            var typeParameters = ImmutableArray.Create(typeParameter1.Object, typeParameter2.Object);
+
+            var typeSymbolWithTypeParameters = new Mock<INamedTypeSymbol>();
+            typeSymbolWithTypeParameters.Setup(s => s.ToString()).Returns("typeSymbolStringForm(xyz)");
+            typeSymbolWithTypeParameters.Setup(s => s.IsGenericType).Returns(false);
+            typeSymbolWithTypeParameters.Setup(s => s.TypeParameters).Returns(typeParameters);
+
+            var getClassNameWithNamespace = TestUtils.GetPrivateStaticMethod(typeof(InvocationExpressionHandler), "GetClassNameWithNamespace");
+            var typeNameWithTypeParametersInCSharpSyntax = getClassNameWithNamespace.Invoke(null, new object[] { typeSymbolWithTypeParameters.Object });
+
+            Assert.AreEqual("typeSymbolStringForm(xyz)", typeNameWithTypeParametersInCSharpSyntax);
+        }
+
+    }
+}

--- a/tst/Codelyzer.Analysis.Tests/TestUtils.cs
+++ b/tst/Codelyzer.Analysis.Tests/TestUtils.cs
@@ -19,6 +19,19 @@ namespace Codelyzer.Analysis.Tests
             return method;
         }
 
+        public static MethodInfo GetPrivateStaticMethod(Type type, string methodName)
+        {
+            if (string.IsNullOrWhiteSpace(methodName))
+                Assert.Fail("methodName cannot be null or whitespace");
+
+            var method = type.GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static);
+
+            if (method == null)
+                Assert.Fail("{0} method not found", methodName);
+
+            return method;
+        }
+
         public static PropertyInfo GetPrivateProperty(Type type, string propertyName)
         {
             if (string.IsNullOrWhiteSpace(propertyName))


### PR DESCRIPTION
## Description
* Convert VB generic type definitions to original definitions using CSharp syntax

## Supplemental testing
Describe any testing done in addition to existing unit tests

## Additional context
Please provide any additional information related to this PR

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
