### PR TITLE
fix object null reference error if compilation is null

### DIFF
--- a/src/Analysis/Codelyzer.Analysis/CSharpCodeAnalyzer.cs
+++ b/src/Analysis/Codelyzer.Analysis/CSharpCodeAnalyzer.cs
@@ -232,7 +232,7 @@ namespace Codelyzer.Analysis
             {
                 SourceFiles = new UstList<string>(projectResult.SourceFiles),
                 BuildErrors = projectResult.BuildErrors,
-                BuildErrorsCount = projectResult.BuildErrors.Count
+                BuildErrorsCount = projectResult.BuildErrors== null? 0: projectResult.BuildErrors.Count
             };
 
             if (AnalyzerConfiguration.MetaDataSettings.ReferenceData)

--- a/src/Analysis/Codelyzer.Analysis/VisualBasicCodeAnalyzer.cs
+++ b/src/Analysis/Codelyzer.Analysis/VisualBasicCodeAnalyzer.cs
@@ -204,7 +204,7 @@ namespace Codelyzer.Analysis
             {
                 SourceFiles = new UstList<string>(projectResult.SourceFiles),
                 BuildErrors = projectResult.BuildErrors,
-                BuildErrorsCount = projectResult.BuildErrors.Count
+                BuildErrorsCount = projectResult.BuildErrors == null ? 0: projectResult.BuildErrors.Count
             };
 
             if (AnalyzerConfiguration.MetaDataSettings.ReferenceData)


### PR DESCRIPTION
Null object reference for CreateManualCompilation object. 
if project is not csproj or vbproj. 
